### PR TITLE
Update packaging and use latest telliot-core

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+# Per:
+# https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+# https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+
+name: Publish
+
+on:
+  release:
+    types: [published, released]
+
+jobs:
+  build-n-publish:
+    name: Publish telliot-feed-examples
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.9
+
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+    - name: Publish telliot-feed-examples to Test PyPI
+      if: "github.event.release.prerelease"
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.TELLIOT_FEED_EXAMPLES_TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+
+    - name: Publish telliot-feed-examples to PyPI
+      if: "!github.event.release.prerelease"
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.TELLIOT_FEED_EXAMPLES_PYPI_API_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,8 +13,8 @@ repos:
     rev: v2.6.0
     hooks:
       - id: reorder-python-imports
-        name: Reorder Python imports (pysigner, tests)
-        args: ["--application-directories=.:pysigner:tests"]
+        name: Reorder Python imports
+        args: ["--application-directories=.:src:tests"]
   - repo: https://github.com/psf/black
     rev: 21.7b0
     hooks:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
--r requirements.txt
 mkdocs-material
 mkdocstrings
 pytest
@@ -8,4 +7,6 @@ pytest-asyncio
 pre-commit
 mypy
 mypy-extensions
+types-requests
+types-PyYAML
 tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-telliot-core==0.0.2
-pydantic==1.8.2

--- a/scripts/report_usd_vwap.py
+++ b/scripts/report_usd_vwap.py
@@ -8,6 +8,7 @@ from telliot_core.apps.telliot_config import TelliotConfig
 from telliot_core.contract.contract import Contract
 from telliot_core.utils.abi import rinkeby_tellor_master
 from telliot_core.utils.abi import rinkeby_tellor_oracle
+
 from telliot_feed_examples.feeds.usd_vwap import ampl_usd_vwap_feed
 from telliot_feed_examples.reporters.interval import IntervalReporter
 

--- a/scripts/report_uspce.py
+++ b/scripts/report_uspce.py
@@ -6,6 +6,7 @@ from telliot_core.apps.telliot_config import TelliotConfig
 from telliot_core.contract.contract import Contract
 from telliot_core.utils.abi import rinkeby_tellor_master
 from telliot_core.utils.abi import rinkeby_tellor_oracle
+
 from telliot_feed_examples.feeds.uspce import uspce_feed
 from telliot_feed_examples.reporters.interval import IntervalReporter
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ tests_require =
     tox
     telliot-core
 install_requires =
-    telliot-core
+    telliot-core >= 0.0.4
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,9 +39,10 @@ tests_require =
     pytest-asyncio
     pytest-cov
     tox
-    telliot-core
+    tox-travis
 install_requires =
     telliot-core >= 0.0.4
+    pydantic
 
 [options.packages.find]
 where = src

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()

--- a/src/telliot_feed_examples/feeds/ampl_usd_vwap_feed.py
+++ b/src/telliot_feed_examples/feeds/ampl_usd_vwap_feed.py
@@ -1,6 +1,7 @@
 """Example datafeed used by AMPLUSDVWAPReporter."""
 from telliot_core.datafeed import DataFeed
 from telliot_core.queries.legacy_query import LegacyRequest
+
 from telliot_feed_examples.config.ampl import AMPLConfig
 from telliot_feed_examples.sources.ampl_usd_vwap import AMPLUSDVWAPSource
 

--- a/src/telliot_feed_examples/feeds/btc_usd_feed.py
+++ b/src/telliot_feed_examples/feeds/btc_usd_feed.py
@@ -1,6 +1,7 @@
 """Example datafeed used by BTCUSDReporter."""
 from telliot_core.datafeed import DataFeed
 from telliot_core.queries.coin_price import CoinPrice
+
 from telliot_feed_examples.sources.bittrex import BittrexPriceSource
 from telliot_feed_examples.sources.coinbase import CoinbasePriceSource
 from telliot_feed_examples.sources.coingecko import CoinGeckoPriceSource

--- a/src/telliot_feed_examples/feeds/eth_jpy_feed.py
+++ b/src/telliot_feed_examples/feeds/eth_jpy_feed.py
@@ -1,6 +1,7 @@
 """Datafeed for current price of ETH in JPY used by LegacyQueryReporter."""
 from telliot_core.datafeed import DataFeed
 from telliot_core.queries import LegacyRequest
+
 from telliot_feed_examples.sources.bitfinex import BitfinexPriceSource
 from telliot_feed_examples.sources.bitflyer import BitflyerPriceSource
 from telliot_feed_examples.sources.coingecko import CoinGeckoPriceSource

--- a/src/telliot_feed_examples/feeds/eth_usd_feed.py
+++ b/src/telliot_feed_examples/feeds/eth_usd_feed.py
@@ -1,6 +1,7 @@
 """Datafeed for current price of ETH in USD used by LegacyQueryReporter."""
 from telliot_core.datafeed import DataFeed
 from telliot_core.queries import LegacyRequest
+
 from telliot_feed_examples.sources.binance import BinancePriceSource
 from telliot_feed_examples.sources.coinbase import CoinbasePriceSource
 from telliot_feed_examples.sources.coingecko import CoinGeckoPriceSource

--- a/src/telliot_feed_examples/feeds/trb_usd_feed.py
+++ b/src/telliot_feed_examples/feeds/trb_usd_feed.py
@@ -1,6 +1,7 @@
 """Datafeed for current price of TRB in USD used by LegacyQueryReporter."""
 from telliot_core.datafeed import DataFeed
 from telliot_core.queries import LegacyRequest
+
 from telliot_feed_examples.sources.coingecko import CoinGeckoPriceSource
 from telliot_feed_examples.sources.price_aggregator import PriceAggregator
 

--- a/src/telliot_feed_examples/feeds/uspce_feed.py
+++ b/src/telliot_feed_examples/feeds/uspce_feed.py
@@ -1,6 +1,7 @@
 """Example datafeed used by USPCEReporter."""
 from telliot_core.datafeed import DataFeed
 from telliot_core.queries.legacy_query import LegacyRequest
+
 from telliot_feed_examples.sources.uspce import USPCESource
 
 

--- a/src/telliot_feed_examples/reporters/report_legacy_price.py
+++ b/src/telliot_feed_examples/reporters/report_legacy_price.py
@@ -8,6 +8,7 @@ from telliot_core.contract.contract import Contract
 from telliot_core.datafeed import DataFeed
 from telliot_core.utils.abi import rinkeby_tellor_master
 from telliot_core.utils.abi import rinkeby_tellor_oracle
+
 from telliot_feed_examples.feeds.btc_usd_feed import btc_usd_median_feed
 from telliot_feed_examples.feeds.eth_jpy_feed import eth_jpy_median_feed
 from telliot_feed_examples.feeds.eth_usd_feed import eth_usd_median_feed

--- a/src/telliot_feed_examples/sources/ampl_usd_vwap.py
+++ b/src/telliot_feed_examples/sources/ampl_usd_vwap.py
@@ -17,6 +17,7 @@ from telliot_core.datasource import DataSource
 from telliot_core.types.datapoint import datetime_now_utc
 from telliot_core.types.datapoint import OptionalDataPoint
 from telliot_core.utils.response import ResponseStatus
+
 from telliot_feed_examples.config.ampl import AMPLConfig
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,7 @@ import time
 import pytest
 from telliot_core.apps.telliot_config import TelliotConfig
 from telliot_core.contract.contract import Contract
-from telliot_core.utils.abi import rinkeby_tellor_master
-from telliot_core.utils.abi import rinkeby_tellor_oracle
+from telliot_core.directory.tellorx import tellor_directory
 from telliot_feed_examples.feeds.uspce_feed import uspce_feed
 from telliot_feed_examples.reporters.interval import IntervalReporter
 from telliot_feed_examples.sources import uspce
@@ -14,7 +13,7 @@ from web3.datastructures import AttributeDict
 
 
 @pytest.fixture(scope="session", autouse=True)
-def cfg():
+def rinkeby_cfg():
     """Get rinkeby endpoint from config
 
     If environment variables are defined, they will override the values in config files
@@ -38,46 +37,48 @@ def cfg():
 
 
 @pytest.fixture(scope="session")
-def master(cfg):
+def master(rinkeby_cfg):
     """Helper function for connecting to a contract at an address"""
-    endpoint = cfg.get_endpoint()
+    tellor_master = tellor_directory.find(chain_id=4, name="master")[0]
+    endpoint = rinkeby_cfg.get_endpoint()
     endpoint.connect()
     master = Contract(
-        address="0x657b95c228A5de81cdc3F85be7954072c08A6042",
-        abi=rinkeby_tellor_master,
+        address=tellor_master.address,  # "0x657b95c228A5de81cdc3F85be7954072c08A6042",
+        abi=tellor_master.abi,
         node=endpoint,
-        private_key=cfg.main.private_key,
+        private_key=rinkeby_cfg.main.private_key,
     )
     master.connect()
     return master
 
 
 @pytest.fixture(scope="session", autouse=True)
-def oracle(cfg):
+def oracle(rinkeby_cfg):
     """Helper function for connecting to a contract at an address"""
-    endpoint = cfg.get_endpoint()
+    tellor_oracle = tellor_directory.find(chain_id=4, name="oracle")[0]
+    endpoint = rinkeby_cfg.get_endpoint()
     endpoint.connect()
     oracle = Contract(
-        address="0x07b521108788C6fD79F471D603A2594576D47477",
-        abi=rinkeby_tellor_oracle,
+        address=tellor_oracle.address,  # "0x07b521108788C6fD79F471D603A2594576D47477",
+        abi=tellor_oracle.abi,
         node=endpoint,
-        private_key=cfg.main.private_key,
+        private_key=rinkeby_cfg.main.private_key,
     )
     oracle.connect()
     return oracle
 
 
-async def reporter_submit_once(cfg, master, oracle, feed):
+async def reporter_submit_once(rinkeby_cfg, master, oracle, feed):
     """Test reporting once to the TellorX playground on Rinkeby
     with three retries."""
 
-    rinkeby_endpoint = cfg.get_endpoint()
+    rinkeby_endpoint = rinkeby_cfg.get_endpoint()
 
     if feed == uspce_feed:
         # Override Python built-in input method
         uspce.input = lambda: "123.456"
 
-    user = rinkeby_endpoint.web3.eth.account.from_key(cfg.main.private_key).address
+    user = rinkeby_endpoint.web3.eth.account.from_key(rinkeby_cfg.main.private_key).address
     last_timestamp, read_status = await oracle.read(
         "getReporterLastTimestamp", _reporter=user
     )
@@ -85,7 +86,7 @@ async def reporter_submit_once(cfg, master, oracle, feed):
 
     reporter = IntervalReporter(
         endpoint=rinkeby_endpoint,
-        private_key=cfg.main.private_key,
+        private_key=rinkeby_cfg.main.private_key,
         master=master,
         oracle=oracle,
         datafeeds=[feed],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,10 +6,11 @@ import pytest
 from telliot_core.apps.telliot_config import TelliotConfig
 from telliot_core.contract.contract import Contract
 from telliot_core.directory.tellorx import tellor_directory
+from web3.datastructures import AttributeDict
+
 from telliot_feed_examples.feeds.uspce_feed import uspce_feed
 from telliot_feed_examples.reporters.interval import IntervalReporter
 from telliot_feed_examples.sources import uspce
-from web3.datastructures import AttributeDict
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -78,7 +79,9 @@ async def reporter_submit_once(rinkeby_cfg, master, oracle, feed):
         # Override Python built-in input method
         uspce.input = lambda: "123.456"
 
-    user = rinkeby_endpoint.web3.eth.account.from_key(rinkeby_cfg.main.private_key).address
+    user = rinkeby_endpoint.web3.eth.account.from_key(
+        rinkeby_cfg.main.private_key
+    ).address
     last_timestamp, read_status = await oracle.read(
         "getReporterLastTimestamp", _reporter=user
     )

--- a/tests/feeds/test_ampl_usd_vwap_feed.py
+++ b/tests/feeds/test_ampl_usd_vwap_feed.py
@@ -1,4 +1,5 @@
 import yaml
+
 from telliot_feed_examples.feeds.ampl_usd_vwap_feed import ampl_usd_vwap_feed
 
 

--- a/tests/feeds/test_btc_usd_feed.py
+++ b/tests/feeds/test_btc_usd_feed.py
@@ -2,6 +2,7 @@ import statistics
 
 import pytest
 from telliot_core.queries.query import OracleQuery
+
 from telliot_feed_examples.feeds.btc_usd_feed import btc_usd_median_feed
 
 

--- a/tests/feeds/test_eth_jpy_feed.py
+++ b/tests/feeds/test_eth_jpy_feed.py
@@ -1,6 +1,7 @@
 import statistics
 
 import pytest
+
 from telliot_feed_examples.feeds.eth_jpy_feed import eth_jpy_median_feed
 
 

--- a/tests/feeds/test_eth_usd_feed.py
+++ b/tests/feeds/test_eth_usd_feed.py
@@ -1,6 +1,7 @@
 import statistics
 
 import pytest
+
 from telliot_feed_examples.feeds.eth_usd_feed import eth_usd_median_feed
 
 

--- a/tests/feeds/test_trb_usd_feed.py
+++ b/tests/feeds/test_trb_usd_feed.py
@@ -1,6 +1,7 @@
 import statistics
 
 import pytest
+
 from telliot_feed_examples.feeds.trb_usd_feed import trb_usd_median_feed
 
 

--- a/tests/feeds/test_uspce_feed.py
+++ b/tests/feeds/test_uspce_feed.py
@@ -1,4 +1,5 @@
 import yaml
+
 from telliot_feed_examples.feeds.uspce_feed import uspce_feed
 
 

--- a/tests/reporters/test_ampl_usd_vwap_reporter.py
+++ b/tests/reporters/test_ampl_usd_vwap_reporter.py
@@ -1,6 +1,6 @@
 import pytest
-from telliot_feed_examples.feeds.ampl_usd_vwap_feed import ampl_usd_vwap_feed
 
+from telliot_feed_examples.feeds.ampl_usd_vwap_feed import ampl_usd_vwap_feed
 from tests.conftest import reporter_submit_once
 
 

--- a/tests/reporters/test_ampl_usd_vwap_reporter.py
+++ b/tests/reporters/test_ampl_usd_vwap_reporter.py
@@ -6,7 +6,7 @@ from tests.conftest import reporter_submit_once
 
 # @pytest.mark.skip("uninvestigated error")
 @pytest.mark.asyncio
-async def test_uspce_reporter_submit_once(cfg, master, oracle):
+async def test_uspce_reporter_submit_once(rinkeby_cfg, master, oracle):
     """Test reporting AMPL/USD/VWAP to the TellorX Oracle on Rinkeby."""
 
-    await reporter_submit_once(cfg, master, oracle, ampl_usd_vwap_feed)
+    await reporter_submit_once(rinkeby_cfg, master, oracle, ampl_usd_vwap_feed)

--- a/tests/reporters/test_interval_reporter.py
+++ b/tests/reporters/test_interval_reporter.py
@@ -12,14 +12,14 @@ from tests.conftest import reporter_submit_once
 playground_address = "0x4699845F22CA2705449CFD532060e04abE3F1F31"
 
 
-def test_reporter_config(cfg, master, oracle):
+def test_reporter_config(rinkeby_cfg, master, oracle):
     """Test instantiating an IntervalReporter using default telliot configs."""
 
-    rinkeby_endpoint = cfg.get_endpoint()
+    rinkeby_endpoint = rinkeby_cfg.get_endpoint()
 
     _ = IntervalReporter(
         endpoint=rinkeby_endpoint,
-        private_key=cfg.main.private_key,
+        private_key=rinkeby_cfg.main.private_key,
         master=master,
         oracle=oracle,
         datafeeds=[btc_usd_median_feed],
@@ -34,11 +34,11 @@ def test_reporter_config(cfg, master, oracle):
 
 # @pytest.mark.skip(reason="Uninvestigated error")
 @pytest.mark.asyncio
-async def test_interval_reporter_submit_once(cfg, master, oracle):
+async def test_interval_reporter_submit_once(rinkeby_cfg, master, oracle):
     """Test reporting once to the TellorX playground on Rinkeby
     with three retries."""
 
-    await reporter_submit_once(cfg, master, oracle, btc_usd_median_feed)
+    await reporter_submit_once(rinkeby_cfg, master, oracle, btc_usd_median_feed)
 
 
 # TODO: choose datafeeds in reporters config

--- a/tests/reporters/test_interval_reporter.py
+++ b/tests/reporters/test_interval_reporter.py
@@ -3,9 +3,9 @@ Tests covering the IntervalReporter class from
 telliot's reporters subpackage.
 """
 import pytest
+
 from telliot_feed_examples.feeds.btc_usd_feed import btc_usd_median_feed
 from telliot_feed_examples.reporters.interval import IntervalReporter
-
 from tests.conftest import reporter_submit_once
 
 # Tellor playground contract used for test

--- a/tests/reporters/test_uspce_reporter.py
+++ b/tests/reporters/test_uspce_reporter.py
@@ -1,6 +1,6 @@
 import pytest
-from telliot_feed_examples.feeds.uspce_feed import uspce_feed
 
+from telliot_feed_examples.feeds.uspce_feed import uspce_feed
 from tests.conftest import reporter_submit_once
 
 

--- a/tests/reporters/test_uspce_reporter.py
+++ b/tests/reporters/test_uspce_reporter.py
@@ -5,6 +5,6 @@ from tests.conftest import reporter_submit_once
 
 
 @pytest.mark.asyncio
-async def test_uspce_interval_reporter_submit_once(cfg, master, oracle):
+async def test_uspce_interval_reporter_submit_once(rinkeby_cfg, master, oracle):
     """test report of uspce manual price"""
-    await reporter_submit_once(cfg, master, oracle, uspce_feed)
+    await reporter_submit_once(rinkeby_cfg, master, oracle, uspce_feed)

--- a/tests/sources/test_ampl_usd_vwap_source.py
+++ b/tests/sources/test_ampl_usd_vwap_source.py
@@ -2,6 +2,7 @@ import os
 from datetime import datetime
 
 import pytest
+
 from telliot_feed_examples.config.ampl import AMPLConfig
 from telliot_feed_examples.sources.ampl_usd_vwap import AMPLUSDVWAPSource
 from telliot_feed_examples.sources.ampl_usd_vwap import AnyBlockSource

--- a/tests/sources/test_general_price_sources.py
+++ b/tests/sources/test_general_price_sources.py
@@ -4,6 +4,7 @@
 from datetime import datetime
 
 import pytest
+
 from telliot_feed_examples.sources.bittrex import BittrexPriceService
 from telliot_feed_examples.sources.coinbase import CoinbasePriceService
 from telliot_feed_examples.sources.coingecko import CoinGeckoPriceService

--- a/tests/sources/test_uspce_source.py
+++ b/tests/sources/test_uspce_source.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import pytest
+
 from telliot_feed_examples.sources import uspce
 from telliot_feed_examples.sources.uspce import USPCESource
 

--- a/tests/utils/test_profit_calc.py
+++ b/tests/utils/test_profit_calc.py
@@ -2,6 +2,7 @@
 Test covering Pytelliot EVM contract connection utils.
 """
 import pytest
+
 from telliot_feed_examples.utils.profitcalc import profitable
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     py{38,39}
     style
     typing
-skipdist = true
+skipdist = false
 
 [gh-actions]
 python =
@@ -14,7 +14,6 @@ python =
 [testenv]
 passenv = *
 deps =
-    -rrequirements.txt
     pytest
     pytest-cov
     pytest-dotenv
@@ -29,7 +28,6 @@ commands = pre-commit run --all-files
 
 [testenv:typing]
 deps =
-    -rrequirements.txt
     mypy
     mypy-extensions
     types-requests
@@ -40,7 +38,6 @@ commands = mypy --strict src --implicit-reexport --ignore-missing-imports --disa
 description = invoke sphinx-build to build the HTML docs
 basepython = python3.8
 deps =
-    -rrequirements.txt
     mkdocs-material
     mkdocstrings
 


### PR DESCRIPTION
There are a few changes in this PR, which needed to be done together.

* First, the telliot-core was updated to version 0.0.4, and this PR needs to use it.
The main change in telliot-core was the new contract directory feature (this currently points to the same test contracts and ABI we were using before).  The next version of telliot-core will point to the latest rinkeby contracts.

* The next change was to update the project files to match the telliot-core release flow (and specify a minimum version of 0.0.4).

* Finally, there was an issue with tox style that was running differently on git vs local machine.  This is working now, but unfortunately made tiny changes to the imports of a lot of files.