### PR TITLE
Rinkeby update

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -16,7 +16,7 @@ located in a subfolder called `tenv`:
 
     ```
     python3 -m venv tenv
-    tenv tutorial_env/bin/activate
+    source tenv/bin/activate
     ```
 
 === "Windows"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,7 +3,25 @@
 Installation of Telliot Feed Examples requires that Python 3.8 or greater is already
 installed on your system.
 
+
 ## Install Telliot Feed Examples
+
+*Optional*: Create and activate a [virtual environment](https://docs.python.org/3/library/venv.html).  
+In this example, the virtual environment is located in a subfolder called `tenv`:
+
+=== "Linux"
+
+    ```
+    python3 -m venv tenv
+    source tenv/bin/activate
+    ```
+
+=== "Windows"
+
+    ```
+    py -m venv tenv
+    tenv\Scripts\activate
+    ```
 
 You can install Telliot Feed Examples and all of it's dependencies
 (including `telliot-core`) through the command line:

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ tests_require =
     tox
     tox-travis
 install_requires =
-    telliot-core >= 0.0.4
+    telliot-core >= 0.0.5
     pydantic
 
 [options.packages.find]


### PR DESCRIPTION
- Update installation docs
- Require telliot-core 0.0.5 to use rinkeby