### PR TITLE
Add logging

### DIFF
--- a/scripts/report_usd_vwap.py
+++ b/scripts/report_usd_vwap.py
@@ -11,8 +11,10 @@ from telliot_core.utils.abi import rinkeby_tellor_oracle
 
 from telliot_feed_examples.feeds.usd_vwap import ampl_usd_vwap_feed
 from telliot_feed_examples.reporters.interval import IntervalReporter
+from telliot_feed_examples.utils.log import get_logger
 
-# from datetime import datetime
+
+logger = get_logger(__name__)
 
 
 def get_cfg() -> TelliotConfig:
@@ -34,7 +36,7 @@ def get_master(cfg: TelliotConfig) -> Optional[Contract]:
     """Helper function for connecting to a contract at an address"""
     endpoint = cfg.get_endpoint()
     if not endpoint:
-        print("Could not connect to master contract.")
+        logger.critical("Could not connect to master contract.")
         return None
 
     endpoint.connect()
@@ -52,7 +54,7 @@ def get_oracle(cfg: TelliotConfig) -> Optional[Contract]:
     """Helper function for connecting to a contract at an address"""
     endpoint = cfg.get_endpoint()
     if not endpoint:
-        print("Could not connect to master contract.")
+        logger.critical("Could not connect to master contract.")
         return None
 
     if endpoint:

--- a/src/telliot_feed_examples/cli.py
+++ b/src/telliot_feed_examples/cli.py
@@ -14,6 +14,10 @@ from telliot_core.model.endpoints import RPCEndpoint
 from telliot_feed_examples.feeds.uspce_feed import uspce_feed
 from telliot_feed_examples.reporters.interval import IntervalReporter
 from telliot_feed_examples.reporters.report_legacy_price import get_user_choices
+from telliot_feed_examples.utils.log import get_logger
+
+
+logger = get_logger(__name__)
 
 
 def get_tellor_contracts() -> Tuple[TelliotConfig, Contract, Contract, RPCEndpoint]:
@@ -82,7 +86,8 @@ def legacyid() -> None:
 
     for _, status in receipts_statuses:
         if not status.ok:
-            click.echo(status.error)
+            logger.error(status)
+            # click.echo(status.error)
 
 
 @report.command()
@@ -104,7 +109,8 @@ def uspce() -> None:
 
     for _, status in receipts_statuses:
         if not status.ok:
-            click.echo(status.error)
+            logger.error(status)
+            # click.echo(status.error)
 
 
 if __name__ == "__main__":

--- a/src/telliot_feed_examples/reporters/interval.py
+++ b/src/telliot_feed_examples/reporters/interval.py
@@ -16,6 +16,11 @@ from telliot_core.model.endpoints import RPCEndpoint
 from telliot_core.utils.response import ResponseStatus
 from web3.datastructures import AttributeDict
 
+from telliot_feed_examples.utils.log import get_logger
+
+
+logger = get_logger(__name__)
+
 
 class IntervalReporter:
     """Reports values from given datafeeds to a TellorX Oracle
@@ -80,7 +85,7 @@ class IntervalReporter:
 
             else:
 
-                # print("stake status:", is_staked[0])
+                logger.info(f"stake status: {is_staked[0]}")
 
                 # Status 1: staked
                 if is_staked[0] == 1:
@@ -130,15 +135,15 @@ class IntervalReporter:
                                 transaction_receipts.append((tx_receipt, status))
 
                             else:
-                                print(
+                                logger.warning(
                                     f"Skipping submission for {repr(datafeed)}, "
                                     f"no query for datafeed."
-                                )  # TODO logging
+                                )
                         else:
-                            print(
+                            logger.warning(
                                 f"Skipping submission for {repr(datafeed)}, "
                                 f"datafeed value not updated."
-                            )  # TODO logging
+                            )
                 else:
                     # Status 3: disputed
                     if is_staked[0] == 3:

--- a/src/telliot_feed_examples/reporters/report_legacy_price.py
+++ b/src/telliot_feed_examples/reporters/report_legacy_price.py
@@ -14,6 +14,10 @@ from telliot_feed_examples.feeds.eth_jpy_feed import eth_jpy_median_feed
 from telliot_feed_examples.feeds.eth_usd_feed import eth_usd_median_feed
 from telliot_feed_examples.feeds.trb_usd_feed import trb_usd_median_feed
 from telliot_feed_examples.reporters.interval import IntervalReporter
+from telliot_feed_examples.utils.log import get_logger
+
+
+logger = get_logger(__name__)
 
 
 def get_rinkeby_config() -> TelliotConfig:
@@ -35,7 +39,7 @@ def get_master(cfg: TelliotConfig) -> Optional[Contract]:
     """Helper function for connecting to a contract at an address"""
     endpoint = cfg.get_endpoint()
     if not endpoint:
-        print("Could not connect to master contract.")
+        logger.critical("Could not connect to master contract.")
         return None
 
     tellor_master_rinkeby = tellor_directory.find(
@@ -57,7 +61,7 @@ def get_oracle(cfg: TelliotConfig) -> Optional[Contract]:
     """Helper function for connecting to a contract at an address"""
     endpoint = cfg.get_endpoint()
     if not endpoint:
-        print("Could not connect to master contract.")
+        logger.critical("Could not connect to master contract.")
         return None
 
     if endpoint:
@@ -97,7 +101,7 @@ def get_user_choices() -> List[DataFeed]:
             selected = [s.strip() for s in selected.split(",")]  # type: ignore
             good_input = True
         except ValueError:
-            print(
+            logger.info(
                 """Invalid user input. \
                 Enter integers separated by commas (example: "2, 50, 59")."""
             )

--- a/src/telliot_feed_examples/sources/ampl_usd_vwap.py
+++ b/src/telliot_feed_examples/sources/ampl_usd_vwap.py
@@ -19,8 +19,10 @@ from telliot_core.types.datapoint import OptionalDataPoint
 from telliot_core.utils.response import ResponseStatus
 
 from telliot_feed_examples.config.ampl import AMPLConfig
+from telliot_feed_examples.utils.log import get_logger
 
 
+logger = get_logger(__name__)
 T = TypeVar("T")
 
 
@@ -219,7 +221,6 @@ class AMPLUSDVWAPSource(DataSource[float]):
             Current time-stamped value
         """
         updates = await self.update_sources()
-        print(updates)
 
         prices = [v for v, _ in updates if v is not None]
 
@@ -228,7 +229,7 @@ class AMPLUSDVWAPSource(DataSource[float]):
         datapoint = (result, datetime_now_utc())
         self.store_datapoint(datapoint)
 
-        print(
+        logger.info(
             "AMPL/USD/VWAP {} retrieved at time {}".format(datapoint[0], datapoint[1])
         )
 

--- a/src/telliot_feed_examples/sources/binance.py
+++ b/src/telliot_feed_examples/sources/binance.py
@@ -8,6 +8,10 @@ from telliot_core.pricing.price_source import PriceSource
 from telliot_core.types.datapoint import datetime_now_utc
 from telliot_core.types.datapoint import OptionalDataPoint
 
+from telliot_feed_examples.utils.log import get_logger
+
+
+logger = get_logger(__name__)
 
 # Hardcoded supported assets & currencies
 binance_assets = {"ETH"}
@@ -44,7 +48,7 @@ class BinancePriceService(WebPriceService):
         d = self.get_url(request_url)
 
         if "error" in d:
-            print(d)  # TODO: Log
+            logger.error(d)
             return None, None
 
         elif "response" in d:
@@ -54,7 +58,7 @@ class BinancePriceService(WebPriceService):
                 price = float(response[0][4])
             except KeyError as e:
                 msg = f"Error parsing Binance API response: KeyError: {e}"
-                print(msg)
+                logger.warning(msg)
 
         else:
             raise Exception("Invalid response from get_url")

--- a/src/telliot_feed_examples/sources/bitfinex.py
+++ b/src/telliot_feed_examples/sources/bitfinex.py
@@ -7,6 +7,11 @@ from telliot_core.pricing.price_source import PriceSource
 from telliot_core.types.datapoint import datetime_now_utc
 from telliot_core.types.datapoint import OptionalDataPoint
 
+from telliot_feed_examples.utils.log import get_logger
+
+
+logger = get_logger(__name__)
+
 
 # Hardcoded supported assets & currencies
 bitfinex_assets = {"ETH"}
@@ -39,7 +44,7 @@ class BitfinexPriceService(WebPriceService):
         d = self.get_url(request_url)
 
         if "error" in d:
-            print(d)  # TODO: Log
+            logger.error(d)
             return None, None
 
         elif "response" in d:
@@ -49,7 +54,7 @@ class BitfinexPriceService(WebPriceService):
                 price = float(response[6])
             except KeyError as e:
                 msg = f"Error parsing Coingecko API response: KeyError: {e}"
-                print(msg)
+                logger.critical(msg)
 
         else:
             raise Exception("Invalid response from get_url")

--- a/src/telliot_feed_examples/sources/bitflyer.py
+++ b/src/telliot_feed_examples/sources/bitflyer.py
@@ -8,6 +8,11 @@ from telliot_core.pricing.price_source import PriceSource
 from telliot_core.types.datapoint import datetime_now_utc
 from telliot_core.types.datapoint import OptionalDataPoint
 
+from telliot_feed_examples.utils.log import get_logger
+
+
+logger = get_logger(__name__)
+
 
 # Hardcoded supported assets & currencies
 bitflyer_assets = {"ETH"}
@@ -43,7 +48,7 @@ class BitflyerPriceService(WebPriceService):
         d = self.get_url(request_url)
 
         if "error" in d:
-            print(d)  # TODO: Log
+            logger.error(d)
             return None, None
 
         elif "response" in d:
@@ -53,7 +58,7 @@ class BitflyerPriceService(WebPriceService):
                 price = float(response["ltp"])
             except KeyError as e:
                 msg = f"Error parsing Coingecko API response: KeyError: {e}"
-                print(msg)
+                logger.critical(msg)
 
         else:
             raise Exception("Invalid response from get_url")

--- a/src/telliot_feed_examples/sources/bittrex.py
+++ b/src/telliot_feed_examples/sources/bittrex.py
@@ -9,6 +9,11 @@ from telliot_core.pricing.price_source import PriceSource
 from telliot_core.types.datapoint import datetime_now_utc
 from telliot_core.types.datapoint import OptionalDataPoint
 
+from telliot_feed_examples.utils.log import get_logger
+
+
+logger = get_logger(__name__)
+
 
 class BittrexQuote(BaseModel):
     Bid: float
@@ -46,7 +51,7 @@ class BittrexPriceService(WebPriceService):
         d = self.get_url(request_url)
 
         if "error" in d:
-            print(d)  # TODO: Log
+            logger.error(d)
             return None, None
 
         else:
@@ -57,7 +62,7 @@ class BittrexPriceService(WebPriceService):
                 else:
                     return None, None
             else:
-                print(r.message)
+                logger.error(r.message)
                 return None, None
 
 

--- a/src/telliot_feed_examples/sources/coinbase.py
+++ b/src/telliot_feed_examples/sources/coinbase.py
@@ -7,6 +7,11 @@ from telliot_core.pricing.price_source import PriceSource
 from telliot_core.types.datapoint import datetime_now_utc
 from telliot_core.types.datapoint import OptionalDataPoint
 
+from telliot_feed_examples.utils.log import get_logger
+
+
+logger = get_logger(__name__)
+
 
 class CoinbasePriceService(WebPriceService):
     """Coinbase Price Service"""
@@ -31,14 +36,14 @@ class CoinbasePriceService(WebPriceService):
 
         d = self.get_url(request_url)
         if "error" in d:
-            print(d)  # TODO: Log
+            logger.error(d)
             return None, None
 
         elif "response" in d:
             response = d["response"]
 
             if "message" in response:
-                print("API ERROR ({}): {}".format(self.name, response["message"]))
+                logger.error(f"API ERROR ({self.name}): {response['message']}")
                 return None, None
 
         else:

--- a/src/telliot_feed_examples/sources/coingecko.py
+++ b/src/telliot_feed_examples/sources/coingecko.py
@@ -8,6 +8,11 @@ from telliot_core.pricing.price_source import PriceSource
 from telliot_core.types.datapoint import datetime_now_utc
 from telliot_core.types.datapoint import OptionalDataPoint
 
+from telliot_feed_examples.utils.log import get_logger
+
+
+logger = get_logger(__name__)
+
 # Coinbase API uses the 'id' field from /coins/list.
 # Using a manual mapping for now.
 coingecko_coin_id = {"btc": "bitcoin", "eth": "ethereum", "trb": "tellor"}
@@ -43,7 +48,7 @@ class CoinGeckoPriceService(WebPriceService):
         d = self.get_url(request_url)
 
         if "error" in d:
-            print(d)  # TODO: Log
+            logger.error(d)
             return None, None
 
         elif "response" in d:
@@ -53,7 +58,7 @@ class CoinGeckoPriceService(WebPriceService):
                 price = float(response[coin_id][currency])
             except KeyError as e:
                 msg = "Error parsing Coingecko API response: KeyError: {}".format(e)
-                print(msg)
+                logger.critical(msg)
 
         else:
             raise Exception("Invalid response from get_url")

--- a/src/telliot_feed_examples/sources/gemini.py
+++ b/src/telliot_feed_examples/sources/gemini.py
@@ -9,6 +9,11 @@ from telliot_core.pricing.price_source import PriceSource
 from telliot_core.types.datapoint import datetime_now_utc
 from telliot_core.types.datapoint import OptionalDataPoint
 
+from telliot_feed_examples.utils.log import get_logger
+
+
+logger = get_logger(__name__)
+
 
 class GeminiPriceResponse(BaseModel):
     bid: float
@@ -47,9 +52,8 @@ class GeminiPriceService(WebPriceService):
         request_url = "/v1/pubticker/{}{}".format(asset.lower(), currency.lower())
 
         d = self.get_url(request_url)
-        # print(d)
         if "error" in d:
-            print(d)  # TODO: Log
+            logger.error(d)
             return None, None
 
         else:
@@ -58,6 +62,7 @@ class GeminiPriceService(WebPriceService):
             if r.last is not None:
                 return r.last, datetime_now_utc()
             else:
+                logger.error(r)
                 return None, None
 
 

--- a/src/telliot_feed_examples/sources/kraken.py
+++ b/src/telliot_feed_examples/sources/kraken.py
@@ -8,6 +8,11 @@ from telliot_core.pricing.price_source import PriceSource
 from telliot_core.types.datapoint import datetime_now_utc
 from telliot_core.types.datapoint import OptionalDataPoint
 
+from telliot_feed_examples.utils.log import get_logger
+
+
+logger = get_logger(__name__)
+
 
 # Hardcoded supported assets & currencies
 kraken_assets = {"ETH"}
@@ -42,7 +47,7 @@ class KrakenPriceService(WebPriceService):
         d = self.get_url(request_url)
 
         if "error" in d:
-            print(d)  # TODO: Log
+            logger.error(d)
             return None, None
 
         elif "response" in d:
@@ -52,7 +57,7 @@ class KrakenPriceService(WebPriceService):
                 price = float(response["result"][f"X{asset}Z{currency}"]["c"][0])
             except KeyError as e:
                 msg = f"Error parsing Kraken API response: KeyError: {e}"
-                print(msg)
+                logger.critical(msg)
 
         else:
             raise Exception("Invalid response from get_url")

--- a/src/telliot_feed_examples/sources/price_aggregator.py
+++ b/src/telliot_feed_examples/sources/price_aggregator.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 import statistics
 from abc import ABC
 from dataclasses import dataclass
@@ -13,7 +12,10 @@ from telliot_core.pricing.price_source import PriceSource
 from telliot_core.types.datapoint import datetime_now_utc
 from telliot_core.types.datapoint import OptionalDataPoint
 
-logger = logging.getLogger(__name__)
+from telliot_feed_examples.utils.log import get_logger
+
+
+logger = get_logger(__name__)
 
 
 @dataclass
@@ -81,11 +83,13 @@ class PriceAggregator(DataSource[float], ABC):
                 prices.append(v)
 
         # Run the algorithm on all valid prices
-        print(f"Running {self.algorithm} on {prices}")
+        logger.info(f"Running {self.algorithm} on {prices}")
         result = self._algorithm(prices)
         datapoint = (result, datetime_now_utc())
         self.store_datapoint(datapoint)
 
-        print("Feed Price: {} reported at time {}".format(datapoint[0], datapoint[1]))
+        logger.info(
+            "Feed Price: {} reported at time {}".format(datapoint[0], datapoint[1])
+        )
 
         return datapoint

--- a/src/telliot_feed_examples/sources/uspce.py
+++ b/src/telliot_feed_examples/sources/uspce.py
@@ -4,6 +4,11 @@ from telliot_core.datasource import DataSource
 from telliot_core.types.datapoint import DataPoint
 from telliot_core.types.datapoint import datetime_now_utc
 
+from telliot_feed_examples.utils.log import get_logger
+
+
+logger = get_logger(__name__)
+
 
 @dataclass
 class USPCESource(DataSource[float]):
@@ -48,6 +53,6 @@ class USPCESource(DataSource[float]):
         datapoint = (uspce, datetime_now_utc())
         self.store_datapoint(datapoint)
 
-        print(f"USPCE {datapoint[0]} retrieved at time {datapoint[1]}")
+        logger.info(f"USPCE {datapoint[0]} retrieved at time {datapoint[1]}")
 
         return datapoint

--- a/src/telliot_feed_examples/utils/log.py
+++ b/src/telliot_feed_examples/utils/log.py
@@ -1,16 +1,19 @@
 import logging
 import sys
+
 from telliot_core.utils.home import default_homedir
 
 
 def get_logger(name: str) -> logging.Logger:
-    '''Telliot feed examples logger
+    """Telliot feed examples logger
 
     Returns a logger that logs to stdout and file. The name arg
     should be the current file name. For example:
     _ = get_logger(name=__name__)
-    '''
+    """
     logger = logging.getLogger(name)
+
+    logger.setLevel(level=logging.INFO)
 
     logs_file = default_homedir() / ("telliot-feed-examples.log")
     logs_file = logs_file.resolve().absolute()
@@ -18,7 +21,9 @@ def get_logger(name: str) -> logging.Logger:
     output_file_handler = logging.FileHandler(logs_file)
     stdout_handler = logging.StreamHandler(sys.stdout)
 
-    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
     output_file_handler.setFormatter(formatter)
     stdout_handler.setFormatter(formatter)
 

--- a/src/telliot_feed_examples/utils/log.py
+++ b/src/telliot_feed_examples/utils/log.py
@@ -1,7 +1,27 @@
 import logging
+import pathlib
 import sys
+from pathlib import Path
 
+from telliot_core.apps.telliot_config import TelliotConfig
 from telliot_core.utils.home import default_homedir
+
+
+cfg = TelliotConfig()
+
+
+def default_logsdir() -> pathlib.Path:
+    """Return default logs directory, creating it if necessary
+
+    Returns:
+        pathlib.Path : Path to logs directory
+    """
+    logsdir = Path(default_homedir() / ("logs"))
+    logsdir = logsdir.resolve().absolute()
+    if not logsdir.is_dir():
+        logsdir.mkdir()
+
+    return logsdir
 
 
 def get_logger(name: str) -> logging.Logger:
@@ -13,9 +33,9 @@ def get_logger(name: str) -> logging.Logger:
     """
     logger = logging.getLogger(name)
 
-    logger.setLevel(level=logging.INFO)
+    logger.setLevel(level=cfg.main.loglevel)
 
-    logs_file = default_homedir() / ("telliot-feed-examples.log")
+    logs_file = default_logsdir() / ("telliot-feed-examples.log")
     logs_file = logs_file.resolve().absolute()
 
     output_file_handler = logging.FileHandler(logs_file)

--- a/src/telliot_feed_examples/utils/log.py
+++ b/src/telliot_feed_examples/utils/log.py
@@ -1,0 +1,28 @@
+import logging
+import sys
+from telliot_core.utils.home import default_homedir
+
+
+def get_logger(name: str) -> logging.Logger:
+    '''Telliot feed examples logger
+
+    Returns a logger that logs to stdout and file. The name arg
+    should be the current file name. For example:
+    _ = get_logger(name=__name__)
+    '''
+    logger = logging.getLogger(name)
+
+    logs_file = default_homedir() / ("telliot-feed-examples.log")
+    logs_file = logs_file.resolve().absolute()
+
+    output_file_handler = logging.FileHandler(logs_file)
+    stdout_handler = logging.StreamHandler(sys.stdout)
+
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    output_file_handler.setFormatter(formatter)
+    stdout_handler.setFormatter(formatter)
+
+    logger.addHandler(output_file_handler)
+    logger.addHandler(stdout_handler)
+
+    return logger

--- a/tests/utils/test_logging.py
+++ b/tests/utils/test_logging.py
@@ -1,15 +1,24 @@
 from logging import Logger
+from pathlib import Path
 
 from telliot_core.utils.home import default_homedir
 
+from telliot_feed_examples.utils.log import default_logsdir
 from telliot_feed_examples.utils.log import get_logger
+
+
+def test_default_logsdir() -> None:
+    """Tests creating default logs directory."""
+    ld = default_homedir()
+    assert isinstance(ld, Path)
+    assert ld.exists()
 
 
 def test_get_logger() -> None:
     """Tests instantiating a logger for the main package."""
     logger = get_logger(__name__)
     log_file = logger.handlers[0].baseFilename
-    expected_log_file = default_homedir() / ("telliot-feed-examples.log")
+    expected_log_file = default_logsdir() / ("telliot-feed-examples.log")
     expected_log_file.resolve().absolute()
 
     assert isinstance(logger, Logger)

--- a/tests/utils/test_logging.py
+++ b/tests/utils/test_logging.py
@@ -1,0 +1,15 @@
+from telliot_feed_examples.utils.log import get_logger
+from telliot_core.utils.home import default_homedir
+from logging import Logger
+
+
+def test_get_logger() -> None:
+    '''Tests instantiating a logger for the main package.'''
+    logger = get_logger(__name__)
+    log_file = logger.handlers[0].baseFilename
+    expected_log_file = default_homedir() / ('telliot-feed-examples.log')
+    expected_log_file.resolve().absolute()
+
+    assert isinstance(logger, Logger)
+    assert log_file == str(expected_log_file)
+    assert logger.name == __name__

--- a/tests/utils/test_logging.py
+++ b/tests/utils/test_logging.py
@@ -1,13 +1,15 @@
-from telliot_feed_examples.utils.log import get_logger
-from telliot_core.utils.home import default_homedir
 from logging import Logger
+
+from telliot_core.utils.home import default_homedir
+
+from telliot_feed_examples.utils.log import get_logger
 
 
 def test_get_logger() -> None:
-    '''Tests instantiating a logger for the main package.'''
+    """Tests instantiating a logger for the main package."""
     logger = get_logger(__name__)
     log_file = logger.handlers[0].baseFilename
-    expected_log_file = default_homedir() / ('telliot-feed-examples.log')
+    expected_log_file = default_homedir() / ("telliot-feed-examples.log")
     expected_log_file.resolve().absolute()
 
     assert isinstance(logger, Logger)


### PR DESCRIPTION
Creates a default logger to use for `telliot-feed-examples`. It prints to stdout and logs to `~/telliot/telliot-feed-examples.log`.
Replaces print statements with logging.

Example usage:
```python
from telliot_feed_examples.utils.log import get_logger

logger = get_logger(__name__)
logger.info("sup")
```