### PR TITLE
convert rewards/profit, add max gas price flag

### DIFF
--- a/src/telliot_feed_examples/cli.py
+++ b/src/telliot_feed_examples/cli.py
@@ -93,9 +93,18 @@ def cli(ctx: Context, private_key: str, chain_id: int) -> None:
     nargs=1,
     type=str,
 )
+@click.option(
+    "--max-gas-price",
+    "-mgp",
+    "max_gas_price",
+    help="maximum gas price used by reporter",
+    nargs=1,
+    type=int,
+    default=0,
+)
 @click.option("--submit-once/--submit-continuous", default=False)
 @click.pass_context
-def report(ctx: Context, legacy_id: str, submit_once: bool) -> None:
+def report(ctx: Context, legacy_id: str, max_gas_price: int, submit_once: bool) -> None:
     """Report values to Tellor oracle"""
 
     # Ensure valid legacy id
@@ -125,6 +134,7 @@ def report(ctx: Context, legacy_id: str, submit_once: bool) -> None:
         master=master,
         oracle=oracle,
         datafeed=chosen_feed,
+        max_gas_price=max_gas_price,
     )
 
     if submit_once:

--- a/src/telliot_feed_examples/reporters/interval.py
+++ b/src/telliot_feed_examples/reporters/interval.py
@@ -180,7 +180,8 @@ class IntervalReporter:
         )
 
         profit = tb_reward + tips - (gas * gas_price_gwei)
-        logger.info(f"Estimated profit: {profit}")
+        profit = round((profit / price_eth_usd) / 1e18, 2)
+        logger.info(f"Estimated profit: ${profit}")
 
         return profit > 0, status
 

--- a/src/telliot_feed_examples/reporters/interval.py
+++ b/src/telliot_feed_examples/reporters/interval.py
@@ -15,6 +15,7 @@ from telliot_core.model.endpoints import RPCEndpoint
 from telliot_core.utils.response import ResponseStatus
 from web3.datastructures import AttributeDict
 
+from telliot_feed_examples.feeds.eth_usd_feed import eth_usd_median_feed
 from telliot_feed_examples.utils.log import get_logger
 
 
@@ -160,7 +161,13 @@ class IntervalReporter:
             status.e = read_status.e
             return False, status
 
+        # Convert rewards to eth
+        await eth_usd_median_feed.source.fetch_new_datapoint()
+        price_eth_usd = eth_usd_median_feed.source.latest[0]
         tips, tb_reward = rewards
+        tips = tips / price_eth_usd
+        tb_reward = tb_reward / price_eth_usd
+
         gas = 500000  # Taken from telliot-core contract write, TODO: optimize
 
         logger.info(


### PR DESCRIPTION
Convert time based reward and query ID tips to eth.
Convert estimated profit to USD.
Add `--max-gas-price/-mgp` optional reporter command flag.