### PR TITLE
added default number of retries to depositStake

### DIFF
--- a/src/telliot_feed_examples/reporters/interval.py
+++ b/src/telliot_feed_examples/reporters/interval.py
@@ -80,7 +80,10 @@ class IntervalReporter:
             logger.info("Address not yet staked. Depositing stake.")
 
             _, write_status = await self.master.write_with_retry(
-                func_name="depositStake", gas_price=gas_price_gwei, extra_gas_price=20
+                func_name="depositStake",
+                gas_price=gas_price_gwei,
+                extra_gas_price=20,
+                retries=5,
             )
 
             if write_status.ok:


### PR DESCRIPTION
the depositStake() call to the oracle contract did not pass in the mandatory argument `num_retries`. it would fail on an unstaked address.