### PR TITLE
prevent logging of reoccuring messages

### DIFF
--- a/src/telliot_feed_examples/reporters/interval.py
+++ b/src/telliot_feed_examples/reporters/interval.py
@@ -98,7 +98,7 @@ class IntervalReporter:
 
         # Status 3: disputed
         if staker_info[0] == 3:
-            status.error = "Current addess disputed. Switch address to continue reporting."  # noqa: E501
+            status.error = "Current address disputed. Switch address to continue reporting."  # noqa: E501
             logger.error(status.error)
             status.e = None
             return False, status

--- a/src/telliot_feed_examples/utils/log.py
+++ b/src/telliot_feed_examples/utils/log.py
@@ -9,6 +9,17 @@ from telliot_core.utils.home import default_homedir
 
 cfg = TelliotConfig()
 
+class DuplicateFilter(logging.Filter):
+    """A logger filter for preventing flood of duplicate log messages"""
+
+    def filter(self, record):
+        """does not print a second consecutive log of the same message"""
+        # add other fields if you need more granular comparison, depends on your app
+        current_log = (record.module, record.levelno, record.msg)
+        if current_log != getattr(self, "last_log", None):
+            self.last_log = current_log
+            return True
+        return False
 
 def default_logsdir() -> pathlib.Path:
     """Return default logs directory, creating it if necessary
@@ -49,5 +60,6 @@ def get_logger(name: str) -> logging.Logger:
 
     logger.addHandler(output_file_handler)
     logger.addHandler(stdout_handler)
+    logger.addFilter(DuplicateFilter())
 
     return logger

--- a/src/telliot_feed_examples/utils/log.py
+++ b/src/telliot_feed_examples/utils/log.py
@@ -9,10 +9,11 @@ from telliot_core.utils.home import default_homedir
 
 cfg = TelliotConfig()
 
+
 class DuplicateFilter(logging.Filter):
     """A logger filter for preventing flood of duplicate log messages"""
 
-    def filter(self, record):
+    def filter(self, record: logging.LogRecord) -> bool:
         """does not print a second consecutive log of the same message"""
         # add other fields if you need more granular comparison, depends on your app
         current_log = (record.module, record.levelno, record.msg)
@@ -20,6 +21,7 @@ class DuplicateFilter(logging.Filter):
             self.last_log = current_log
             return True
         return False
+
 
 def default_logsdir() -> pathlib.Path:
     """Return default logs directory, creating it if necessary

--- a/tests/utils/test_logging.py
+++ b/tests/utils/test_logging.py
@@ -1,4 +1,5 @@
 from logging import Logger
+import os
 from pathlib import Path
 
 from telliot_core.utils.home import default_homedir
@@ -24,3 +25,24 @@ def test_get_logger() -> None:
     assert isinstance(logger, Logger)
     assert log_file == str(expected_log_file)
     assert logger.name == __name__
+
+def test_reocurring_messages() -> None:
+    """Ensure logger filters out recocurring messages"""
+    logger = get_logger(__name__)
+    log_file = logger.handlers[0].baseFilename
+    expected_log_file = default_logsdir() / ("telliot-feed-examples.log")
+    expected_log_file.resolve().absolute()
+    num_lines_before = 0
+    with open(os.path.join(expected_log_file), "r") as f:
+        for line in f:
+            num_lines_before += 1
+
+    for _ in range(5):
+        logger.info("Address not yet staked. Depositing stake.")
+
+    num_lines_after = 0
+    with open(os.path.join(expected_log_file), "r") as f:
+        for line in f:
+            num_lines_after += 1
+
+    assert num_lines_after - num_lines_before == 2

--- a/tests/utils/test_logging.py
+++ b/tests/utils/test_logging.py
@@ -38,7 +38,7 @@ def test_reocurring_messages() -> None:
             num_lines_before += 1
 
     for _ in range(5):
-        logger.info("Address not yet staked. Depositing stake.")
+        logger.info("testttt")
 
     num_lines_after = 0
     with open(os.path.join(expected_log_file), "r") as f:

--- a/tests/utils/test_logging.py
+++ b/tests/utils/test_logging.py
@@ -1,5 +1,5 @@
-from logging import Logger
 import os
+from logging import Logger
 from pathlib import Path
 
 from telliot_core.utils.home import default_homedir
@@ -26,15 +26,15 @@ def test_get_logger() -> None:
     assert log_file == str(expected_log_file)
     assert logger.name == __name__
 
+
 def test_reocurring_messages() -> None:
     """Ensure logger filters out recocurring messages"""
     logger = get_logger(__name__)
-    log_file = logger.handlers[0].baseFilename
     expected_log_file = default_logsdir() / ("telliot-feed-examples.log")
     expected_log_file.resolve().absolute()
     num_lines_before = 0
     with open(os.path.join(expected_log_file), "r") as f:
-        for line in f:
+        for _ in f:
             num_lines_before += 1
 
     for _ in range(5):
@@ -42,7 +42,7 @@ def test_reocurring_messages() -> None:
 
     num_lines_after = 0
     with open(os.path.join(expected_log_file), "r") as f:
-        for line in f:
+        for _ in f:
             num_lines_after += 1
 
     assert num_lines_after - num_lines_before == 2


### PR DESCRIPTION
added a filter and a filter handler to prevent the log from being flooded with repeat messages (annoying!)

the solution for now is to not send a log message if the last line of the log file contains the same message.

Closes #35 