### PR TITLE
Add handling for no updated value retrieved from datafeed

### DIFF
--- a/src/telliot_feed_examples/reporters/interval.py
+++ b/src/telliot_feed_examples/reporters/interval.py
@@ -267,11 +267,10 @@ class IntervalReporter:
         await self.datafeed.source.fetch_new_datapoint()
         latest_data = self.datafeed.source.latest
 
-        if latest_data is None:
-            logger.warning(
-                f"Skipping submission for {repr(self.datafeed)}, "
-                f"datafeed value not updated."
-            )
+        if latest_data[0] is None:
+            status.ok = False
+            status.error = "Unable to retrieve updated datafeed value."
+            logger.error(status.error)
             return None, status
 
         query = self.datafeed.query

--- a/src/telliot_feed_examples/sources/ampl_usd_vwap.py
+++ b/src/telliot_feed_examples/sources/ampl_usd_vwap.py
@@ -224,6 +224,10 @@ class AMPLUSDVWAPSource(DataSource[float]):
 
         prices = [v for v, _ in updates if v is not None]
 
+        if not prices:
+            logger.warning("No prices retrieved for AMPL/USD/VWAP Source.")
+            return None, None
+
         # Get median price
         result = statistics.median(prices)
         datapoint = (result, datetime_now_utc())

--- a/src/telliot_feed_examples/sources/price_aggregator.py
+++ b/src/telliot_feed_examples/sources/price_aggregator.py
@@ -44,6 +44,13 @@ class PriceAggregator(DataSource[float], ABC):
         elif self.algorithm == "mean":
             self._algorithm = statistics.mean
 
+    def __str__(self) -> str:
+        """Human-readable representation."""
+        asset = self.asset.upper()
+        currency = self.currency.upper()
+        symbol = asset + "/" + currency
+        return f"PriceAggregator {symbol} {self.algorithm}"
+
     async def update_sources(self) -> List[OptionalDataPoint[float]]:
         """Update data feed sources
 
@@ -81,6 +88,10 @@ class PriceAggregator(DataSource[float], ABC):
             # Check for valid answers
             if v is not None:
                 prices.append(v)
+
+        if not prices:
+            logger.warning(f"No prices retrieved for {self}.")
+            return None, None
 
         # Run the algorithm on all valid prices
         logger.info(f"Running {self.algorithm} on {prices}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,9 @@ import os
 import pytest
 from telliot_core.apps.telliot_config import TelliotConfig
 from telliot_core.contract.contract import Contract
+from telliot_core.datasource import DataSource
 from telliot_core.directory.tellorx import tellor_directory
+from telliot_core.types.datapoint import OptionalDataPoint
 from web3.datastructures import AttributeDict
 
 from telliot_feed_examples.feeds.uspce_feed import uspce_feed
@@ -74,6 +76,7 @@ EXPECTED_ERRORS = {
     "Current address is in reporter lock.",
     "Estimated profitability below threshold.",
     "Estimated gas price is above maximum gas price.",
+    "Unable to retrieve updated datafeed value.",
 }
 
 
@@ -115,3 +118,16 @@ async def reporter_submit_once(rinkeby_cfg, master, oracle, feed):
         assert not status.ok
         assert status.error in EXPECTED_ERRORS
         print(status.error)
+
+
+@pytest.fixture(scope="session")
+def bad_source():
+    """Used for testing no updated value for datafeeds."""
+
+    class BadSource(DataSource[float]):
+        """Source that does not return an updated DataPoint."""
+
+        async def fetch_new_datapoint(self) -> OptionalDataPoint[float]:
+            return None, None
+
+    return BadSource()

--- a/tests/sources/test_ampl_usd_vwap_source.py
+++ b/tests/sources/test_ampl_usd_vwap_source.py
@@ -63,3 +63,18 @@ async def test_ampl_usd_vwap_source(config):
     assert isinstance(value, float)
     assert isinstance(timestamp, datetime)
     assert value > 0
+
+
+@pytest.mark.asyncio
+async def test_no_updated_value(config, bad_source):
+    """Test no AMPL/USD/VWAP value retrieved."""
+
+    ampl_source = AMPLUSDVWAPSource(cfg=config)
+
+    # Switch source to test one that doesn't return an updated value
+    ampl_source.sources = [bad_source]
+
+    value, timestamp = await ampl_source.fetch_new_datapoint()
+
+    assert value is None
+    assert timestamp is None


### PR DESCRIPTION
Adds handling in the `AMPLUSDVWAPSource` and `PriceAggregator`, so they return `(None, None`) when data sources return no new datapoints. This avoids the error in `statistics.median` that @Spuddyminer reported, because it won't try to find the median of an empty list (`prices`): 
```
     = await asyncio.gather(
  File "/telliot_feed_examples/sources/price_aggregator.py", line 87, in fetch_new_datapoint
    result = self._algorithm(prices)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/statistics.py", line 430, in median
    raise StatisticsError("no median for empty data")
statistics.StatisticsError: no median for empty data
```
Tests for no updated value retrieved.