### PR TITLE
Gas price speed flag

### DIFF
--- a/src/telliot_feed_examples/cli.py
+++ b/src/telliot_feed_examples/cli.py
@@ -103,6 +103,18 @@ def cli(ctx: Context, private_key: str, chain_id: int) -> None:
     default=0,
 )
 @click.option(
+    "--gas-price-speed",
+    "-gps",
+    "gas_price_speed",
+    help="gas price speed for eth gas station API",
+    nargs=1,
+    type=click.Choice(
+        ["safeLow", "average", "fast", "fastest"],
+        case_sensitive=True,
+    ),
+    default="fast",
+)
+@click.option(
     "--profit",
     "-p",
     "profit_percent",
@@ -117,6 +129,7 @@ def report(
     ctx: Context,
     legacy_id: str,
     max_gas_price: int,
+    gas_price_speed: str,
     submit_once: bool,
     profit_percent: float,
 ) -> None:
@@ -136,12 +149,16 @@ def report(
 
     endpoint = cfg.get_endpoint()
 
+    # Print user settings to console
     click.echo(f"Reporting legacy ID: {legacy_id}")
     click.echo(f"Current chain ID: {chain_id}")
     if profit_percent == 0.0:
         click.echo("Reporter not enforcing profit threshold.")
     else:
         click.echo(f"Lower bound for expected percent profit: {profit_percent}%")
+    if max_gas_price != 0:
+        click.echo(f"Reporter will use a maximum gas price of {max_gas_price} gwei.")
+    click.echo(f"Selected gas price speed: {gas_price_speed}")
 
     master, oracle = get_tellor_contracts(
         private_key=private_key, endpoint=endpoint, chain_id=chain_id
@@ -157,6 +174,7 @@ def report(
         datafeed=chosen_feed,
         profit_threshold=profit_percent,
         max_gas_price=max_gas_price,
+        gas_price_speed=gas_price_speed,
     )
 
     if submit_once:

--- a/tests/reporters/test_interval_reporter.py
+++ b/tests/reporters/test_interval_reporter.py
@@ -109,6 +109,23 @@ async def test_no_updated_value(eth_usd_reporter, bad_source):
 
 
 @pytest.mark.asyncio
+async def test_fetch_gas_price(eth_usd_reporter):
+    """Test retrieving custom gas price from eth gas station."""
+    r = eth_usd_reporter
+
+    assert r.gas_price_speed == "fast"
+
+    r.gas_price_speed = "safeLow"
+
+    assert r.gas_price_speed != "fast"
+
+    gas_price = await r.fetch_gas_price()
+
+    assert isinstance(gas_price, int)
+    assert gas_price > 0
+
+
+@pytest.mark.asyncio
 async def test_interval_reporter_submit_once(rinkeby_cfg, master, oracle):
     """Test reporting once to the TellorX playground on Rinkeby
     with three retries."""


### PR DESCRIPTION
Closes #40 
Adds optional flag for setting the estimated gas price speed that's retrieved from [eth gas station API](https://docs.ethgasstation.info/gas-price).

Examples:
```
telliot-examples report -lid 59 --gas-price-speed fastest
```
```
telliot-examples report -lid 1 -gps safeLow
```