### PR TITLE
Do not halve tips

### DIFF
--- a/src/telliot_feed_examples/reporters/interval.py
+++ b/src/telliot_feed_examples/reporters/interval.py
@@ -196,7 +196,7 @@ class IntervalReporter:
             """
         )
 
-        revenue = tb_reward + tips / 2  # Half of tips are burned
+        revenue = tb_reward + tips
         rev_usd = revenue / 1e18 * price_trb_usd
         costs = gas * gas_price_gwei
         costs_usd = costs / 1e9 * price_eth_usd


### PR DESCRIPTION
Corrects profit calculation. Tip halving removed because this already happens in `tipQuery()` (solidity).