### PR TITLE
Add Wrapped Ampleforth / USD report example

### DIFF
--- a/scripts/wampl_report_once.py
+++ b/scripts/wampl_report_once.py
@@ -12,7 +12,6 @@ from telliot_feed_examples.utils.log import get_logger
 logger = get_logger(__name__)
 
 
-
 if __name__ == "__main__":
     cfg = TelliotConfig()
 
@@ -20,7 +19,7 @@ if __name__ == "__main__":
 
     master, oracle = get_tellor_contracts(
         private_key=cfg.main.private_key,
-        chain_id=cfg.main.chain_id, # 4: rinkeby
+        chain_id=cfg.main.chain_id,  # 4: rinkeby
         endpoint=rinkeby_endpoint,
     )
 
@@ -30,7 +29,7 @@ if __name__ == "__main__":
         master=master,
         oracle=oracle,
         datafeed=wampl_usd_median_feed,
-        profit_threshold=0, # does not check profit
+        profit_threshold=0,  # does not check profit
         gas_price=3,
     )
 

--- a/scripts/wampl_report_once.py
+++ b/scripts/wampl_report_once.py
@@ -1,0 +1,37 @@
+"""Submits price of Wrapped Ampleforth in USD to TellorX on Rinkeby."""
+import asyncio
+
+from telliot_core.apps.telliot_config import TelliotConfig
+
+from telliot_feed_examples.cli import get_tellor_contracts
+from telliot_feed_examples.feeds.wampl_usd_feed import wampl_usd_median_feed
+from telliot_feed_examples.reporters.interval import IntervalReporter
+from telliot_feed_examples.utils.log import get_logger
+
+
+logger = get_logger(__name__)
+
+
+
+if __name__ == "__main__":
+    cfg = TelliotConfig()
+
+    rinkeby_endpoint = cfg.get_endpoint()
+
+    master, oracle = get_tellor_contracts(
+        private_key=cfg.main.private_key,
+        chain_id=cfg.main.chain_id, # 4: rinkeby
+        endpoint=rinkeby_endpoint,
+    )
+
+    reporter = IntervalReporter(
+        endpoint=rinkeby_endpoint,
+        private_key=cfg.main.private_key,
+        master=master,
+        oracle=oracle,
+        datafeed=wampl_usd_median_feed,
+        profit_threshold=0, # does not check profit
+        gas_price=3,
+    )
+
+    asyncio.run(reporter.report_once())

--- a/src/telliot_feed_examples/feeds/wampl_usd_feed.py
+++ b/src/telliot_feed_examples/feeds/wampl_usd_feed.py
@@ -1,0 +1,24 @@
+"""Wrapped Ampleforth in USD feed."""
+from telliot_core.datafeed import DataFeed
+from telliot_core.queries import SpotPrice
+
+from telliot_feed_examples.sources.coingecko import CoinGeckoPriceSource
+from telliot_feed_examples.sources.livecoinwatch import LiveCoinWatchPriceSource
+from telliot_feed_examples.sources.price_aggregator import PriceAggregator
+
+wampl_usd_median_feed = DataFeed(
+    query=SpotPrice(
+        asset='wampl',
+        currency='usd',
+    ),
+    source=PriceAggregator(
+        asset="wampl",
+        currency="usd",
+        algorithm="median",
+        sources=[
+            CoinGeckoPriceSource(asset="wampl", currency="usd"),
+            # NomicsPriceSource(asset="wampl", currency="usd"),
+            LiveCoinWatchPriceSource(asset="wampl", currency="usd"),
+        ],
+    ),
+)

--- a/src/telliot_feed_examples/feeds/wampl_usd_feed.py
+++ b/src/telliot_feed_examples/feeds/wampl_usd_feed.py
@@ -8,8 +8,8 @@ from telliot_feed_examples.sources.price_aggregator import PriceAggregator
 
 wampl_usd_median_feed = DataFeed(
     query=SpotPrice(
-        asset='wampl',
-        currency='usd',
+        asset="wampl",
+        currency="usd",
     ),
     source=PriceAggregator(
         asset="wampl",

--- a/src/telliot_feed_examples/sources/coingecko.py
+++ b/src/telliot_feed_examples/sources/coingecko.py
@@ -13,9 +13,15 @@ from telliot_feed_examples.utils.log import get_logger
 
 logger = get_logger(__name__)
 
-# Coinbase API uses the 'id' field from /coins/list.
+# CoinGecko API uses the 'id' field from /coins/list.
+# Coingecko API Token List: https://www.coingecko.com/en/api/documentation
 # Using a manual mapping for now.
-coingecko_coin_id = {"btc": "bitcoin", "eth": "ethereum", "trb": "tellor"}
+coingecko_coin_id = {
+    "btc": "bitcoin",
+    "eth": "ethereum",
+    "trb": "tellor",
+    "wampl": "wrapped-ampleforth",
+}
 
 
 class CoinGeckoPriceService(WebPriceService):

--- a/src/telliot_feed_examples/sources/livecoinwatch.py
+++ b/src/telliot_feed_examples/sources/livecoinwatch.py
@@ -3,7 +3,6 @@ from dataclasses import field
 from typing import Any
 
 import requests
-
 from telliot_core.pricing.price_service import WebPriceService
 from telliot_core.pricing.price_source import PriceSource
 from telliot_core.types.datapoint import datetime_now_utc
@@ -46,15 +45,17 @@ class LiveCoinWatchPriceService(WebPriceService):
         data = '{"currency":"' + currency + '","code":"' + asset + '","meta":false}'
         request_url = "/coins/single"
         headers = {
-            'content-type': 'application/json',
-            'x-api-key': '8c0752b1-1547-41ec-a558-fff37883361e',
+            "content-type": "application/json",
+            "x-api-key": "8c0752b1-1547-41ec-a558-fff37883361e",
         }
 
         request_url = self.url + request_url
 
         with requests.Session() as s:
             try:
-                r = s.post(request_url, timeout=self.timeout, headers=headers, data=data)
+                r = s.post(
+                    request_url, timeout=self.timeout, headers=headers, data=data
+                )
                 json_data = r.json()
                 d = {"response": json_data}
 

--- a/src/telliot_feed_examples/sources/livecoinwatch.py
+++ b/src/telliot_feed_examples/sources/livecoinwatch.py
@@ -1,0 +1,92 @@
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Any
+
+import requests
+
+from telliot_core.pricing.price_service import WebPriceService
+from telliot_core.pricing.price_source import PriceSource
+from telliot_core.types.datapoint import datetime_now_utc
+from telliot_core.types.datapoint import OptionalDataPoint
+
+from telliot_feed_examples.utils.log import get_logger
+
+
+logger = get_logger(__name__)
+
+# LiveCoinWatch API docs:
+# https://livecoinwatch.github.io/lcw-api-docs/#coinssingle
+
+# Hardcoded supported assets & currencies
+livecoinwatch_assets = {"WAMPL"}  # used for "coin code" param
+livecoinwatch_currencies = {"USD"}
+
+
+class LiveCoinWatchPriceService(WebPriceService):
+    """LiveCoinWatch Price Service"""
+
+    def __init__(self, **kwargs: Any) -> None:
+        kwargs["name"] = "LiveCoinWatch Price Service"
+        kwargs["url"] = "https://api.livecoinwatch.com"
+        super().__init__(**kwargs)
+
+    async def get_price(self, asset: str, currency: str) -> OptionalDataPoint[float]:
+        """Implement PriceServiceInterface
+
+        This implementation gets the price from the LiveCoinWatch API."""
+
+        asset = asset.upper()
+        currency = currency.upper()
+
+        if asset not in livecoinwatch_assets:
+            raise Exception(f"Asset not supported: {asset}")
+        if currency not in livecoinwatch_currencies:
+            raise Exception(f"Currency not supported: {currency}")
+
+        data = '{"currency":"' + currency + '","code":"' + asset + '","meta":false}'
+        request_url = "/coins/single"
+        headers = {
+            'content-type': 'application/json',
+            'x-api-key': '8c0752b1-1547-41ec-a558-fff37883361e',
+        }
+
+        request_url = self.url + request_url
+
+        with requests.Session() as s:
+            try:
+                r = s.post(request_url, timeout=self.timeout, headers=headers, data=data)
+                json_data = r.json()
+                d = {"response": json_data}
+
+            except requests.exceptions.ConnectTimeout as e:
+                d = {"error": "Timeout Error", "exception": e}
+
+            except Exception as e:
+                d = {"error": str(type(e)), "exception": e}
+
+        if "error" in d:
+            logger.error(d)
+            return None, None
+
+        elif "response" in d:
+            response = d["response"]
+
+            try:
+                price = float(response["rate"])
+            except KeyError as e:
+                msg = f"Error parsing LiveCoinWatch API response: KeyError: {e}"
+                logger.critical(msg)
+
+        else:
+            raise Exception("Invalid response from get_url")
+
+        return price, datetime_now_utc()
+
+
+@dataclass
+class LiveCoinWatchPriceSource(PriceSource):
+    asset: str = ""
+    currency: str = ""
+    service: LiveCoinWatchPriceService = field(
+        default_factory=LiveCoinWatchPriceService, init=False
+    )


### PR DESCRIPTION
Adds a `DataFeed` for the median price of WAMPL in USD that retrieves values from [CoinGecko](https://www.coingecko.com/en/api/documentation) and [LiveCoinWatch](https://livecoinwatch.github.io/lcw-api-docs/#coinssingle).
Adds a script for reporting WAMPL/USD once without concern for profit.

Needed change within `telliot-core`: [PR #165](https://github.com/tellor-io/telliot-core/pull/165)

[Nomics](https://nomics.com/assets/wampl-wrapped-ampleforth) API could also be used as a price source, but I skipped it since it's paid.

Here's an example submission of WAMPL/USD to Rinkeby testnet using the script: [tx on etherscan](https://rinkeby.etherscan.io/tx/0x8d490464cc336cb61bb9ba7350222fc66dabcbd4d6d959da1cac821a6bf2a3d1)