### PR TITLE
Small changes from reporter users

### DIFF
--- a/src/telliot_feed_examples/cli.py
+++ b/src/telliot_feed_examples/cli.py
@@ -53,12 +53,22 @@ cfg = TelliotConfig()
     nargs=1,
     type=str,
 )
+@click.option(
+    "--gas-limit",
+    "-gl",
+    "gas_limit",
+    help="use custom gas limit",
+    nargs=1,
+    type=int,
+    default=500000,
+)
 @click.pass_context
 def cli(
     ctx: Context,
     private_key: str,
     chain_id: int,
     legacy_id: str,
+    gas_limit: int
 ) -> None:
     """Telliot command line interface"""
     # Ensure valid legacy id
@@ -72,6 +82,7 @@ def cli(
     ctx.obj["PRIVATE_KEY"] = private_key
     ctx.obj["CHAIN_ID"] = chain_id
     ctx.obj["LEGACY_ID"] = legacy_id
+    ctx.obj["GAS_LIMIT"] = gas_limit
 
 
 # Report subcommand options
@@ -107,15 +118,6 @@ def cli(
     required=False,
 )
 @click.option(
-    "--gas",
-    "-g",
-    "custom_gas",
-    help="use custom gas",
-    nargs=1,
-    type=int,
-    default=500000,
-)
-@click.option(
     "--profit",
     "-p",
     "profit_percent",
@@ -129,7 +131,6 @@ def cli(
 def report(
     ctx: Context,
     gas_price: int,
-    custom_gas: int,
     max_gas_price: int,
     gas_price_speed: str,
     submit_once: bool,
@@ -140,6 +141,7 @@ def report(
     private_key = ctx.obj["PRIVATE_KEY"]
     chain_id = ctx.obj["CHAIN_ID"]
     legacy_id = ctx.obj["LEGACY_ID"]
+    gas_limit = ctx.obj["GAS_LIMIT"]
     cfg.main.private_key = private_key
     cfg.main.chain_id = chain_id
 
@@ -164,7 +166,7 @@ def report(
     else:
         click.echo(f"Gas price: {gas_price}")
 
-    click.echo(f"Gas: {custom_gas}")
+    click.echo(f"Gas Limit: {gas_limit}")
 
     # return
     master, oracle = get_tellor_contracts(
@@ -183,7 +185,7 @@ def report(
         gas_price=gas_price,
         max_gas_price=max_gas_price,
         gas_price_speed=gas_price_speed,
-        gas=custom_gas,
+        gas=gas_limit,
     )
 
     if submit_once:

--- a/src/telliot_feed_examples/cli.py
+++ b/src/telliot_feed_examples/cli.py
@@ -64,11 +64,7 @@ cfg = TelliotConfig()
 )
 @click.pass_context
 def cli(
-    ctx: Context,
-    private_key: str,
-    chain_id: int,
-    legacy_id: str,
-    gas_limit: int
+    ctx: Context, private_key: str, chain_id: int, legacy_id: str, gas_limit: int
 ) -> None:
     """Telliot command line interface"""
     # Ensure valid legacy id
@@ -185,7 +181,7 @@ def report(
         gas_price=gas_price,
         max_gas_price=max_gas_price,
         gas_price_speed=gas_price_speed,
-        gas=gas_limit,
+        gas_limit=gas_limit,
     )
 
     if submit_once:

--- a/src/telliot_feed_examples/cli.py
+++ b/src/telliot_feed_examples/cli.py
@@ -3,17 +3,14 @@
 A simple interface for interacting with telliot example feed functionality.
 """
 import asyncio
-from typing import Tuple
 
 import click
 from click.core import Context
 from telliot_core.apps.telliot_config import TelliotConfig
-from telliot_core.contract.contract import Contract
-from telliot_core.directory.tellorx import tellor_directory
-from telliot_core.model.endpoints import RPCEndpoint
 
 from telliot_feed_examples.feeds import LEGACY_DATAFEEDS
 from telliot_feed_examples.reporters.interval import IntervalReporter
+from telliot_feed_examples.utils.contract import get_tellor_contracts
 from telliot_feed_examples.utils.log import get_logger
 from telliot_feed_examples.utils.oracle_write import tip_query
 
@@ -23,34 +20,6 @@ logger = get_logger(__name__)
 
 # Get default configs from ~/telliot/
 cfg = TelliotConfig()
-
-
-def get_tellor_contracts(
-    private_key: str, chain_id: int, endpoint: RPCEndpoint
-) -> Tuple[Contract, Contract]:
-    """Get Contract objects per telliot configuration and
-    CLI flag options."""
-    endpoint.connect()
-
-    tellor_oracle = tellor_directory.find(chain_id=chain_id, name="oracle")[0]
-    oracle = Contract(
-        address=tellor_oracle.address,
-        abi=tellor_oracle.abi,
-        node=endpoint,
-        private_key=private_key,
-    )
-    oracle.connect()
-
-    tellor_master = tellor_directory.find(chain_id=chain_id, name="master")[0]
-    master = Contract(
-        address=tellor_master.address,
-        abi=tellor_master.abi,
-        node=endpoint,
-        private_key=private_key,
-    )
-    master.connect()
-
-    return master, oracle
 
 
 # Main CLI options

--- a/src/telliot_feed_examples/cli.py
+++ b/src/telliot_feed_examples/cli.py
@@ -107,6 +107,15 @@ def cli(
     required=False,
 )
 @click.option(
+    "--gas",
+    "-g",
+    "custom_gas",
+    help="use custom gas",
+    nargs=1,
+    type=int,
+    default=500000,
+)
+@click.option(
     "--profit",
     "-p",
     "profit_percent",
@@ -120,6 +129,7 @@ def cli(
 def report(
     ctx: Context,
     gas_price: int,
+    custom_gas: int,
     max_gas_price: int,
     gas_price_speed: str,
     submit_once: bool,
@@ -152,7 +162,9 @@ def report(
             )
         click.echo(f"Selected gas price speed: {gas_price_speed}")
     else:
-        click.echo(f"Using custom gas price: {gas_price}")
+        click.echo(f"Gas price: {gas_price}")
+
+    click.echo(f"Gas: {custom_gas}")
 
     # return
     master, oracle = get_tellor_contracts(
@@ -171,6 +183,7 @@ def report(
         gas_price=gas_price,
         max_gas_price=max_gas_price,
         gas_price_speed=gas_price_speed,
+        gas=custom_gas,
     )
 
     if submit_once:

--- a/src/telliot_feed_examples/reporters/interval.py
+++ b/src/telliot_feed_examples/reporters/interval.py
@@ -38,7 +38,7 @@ class IntervalReporter:
         gas_price_speed: str = "fast",
         profit_threshold: float = 0.0,
         max_gas_price: int = 0,
-        gas: int = 500000,
+        gas_limit: int = 500000,
     ) -> None:
 
         self.endpoint = endpoint
@@ -51,7 +51,7 @@ class IntervalReporter:
         self.max_gas_price = max_gas_price
         self.gas_price_speed = gas_price_speed
         self.gas_price = gas_price
-        self.gas = gas
+        self.gas_limit = gas_limit
 
         logger.info(f"Reporting with account: {self.user}")
 
@@ -195,14 +195,14 @@ class IntervalReporter:
             f"""
             current tips: {tips / 1e18} TRB
             current tb_reward: {tb_reward / 1e18} TRB
-            gas: {self.gas}
+            gas_limit: {self.gas_limit}
             gas_price_gwei: {gas_price_gwei}
             """
         )
 
         revenue = tb_reward + tips
         rev_usd = revenue / 1e18 * price_trb_usd
-        costs = self.gas * gas_price_gwei
+        costs = self.gas_limit * gas_price_gwei
         costs_usd = costs / 1e9 * price_eth_usd
         profit_usd = rev_usd - costs_usd
         logger.info(f"Estimated profit: ${round(profit_usd, 2)}")

--- a/src/telliot_feed_examples/reporters/interval.py
+++ b/src/telliot_feed_examples/reporters/interval.py
@@ -193,7 +193,7 @@ class IntervalReporter:
         tips, tb_reward = rewards
         logger.info(
             f"""
-            current tips: {tips} (half will be burned)
+            current tips: {tips}
             current tb_reward: {tb_reward}
             gas: {self.gas}
             gas_price_gwei: {gas_price_gwei}

--- a/src/telliot_feed_examples/reporters/interval.py
+++ b/src/telliot_feed_examples/reporters/interval.py
@@ -193,8 +193,8 @@ class IntervalReporter:
         tips, tb_reward = rewards
         logger.info(
             f"""
-            current tips: {tips}
-            current tb_reward: {tb_reward}
+            current tips: {tips / 1e18} TRB
+            current tb_reward: {tb_reward / 1e18} TRB
             gas: {self.gas}
             gas_price_gwei: {gas_price_gwei}
             """

--- a/src/telliot_feed_examples/reporters/interval.py
+++ b/src/telliot_feed_examples/reporters/interval.py
@@ -38,6 +38,7 @@ class IntervalReporter:
         gas_price_speed: str = "fast",
         profit_threshold: float = 0.0,
         max_gas_price: int = 0,
+        gas: int = 500000,
     ) -> None:
 
         self.endpoint = endpoint
@@ -50,6 +51,7 @@ class IntervalReporter:
         self.max_gas_price = max_gas_price
         self.gas_price_speed = gas_price_speed
         self.gas_price = gas_price
+        self.gas = gas
 
         logger.info(f"Reporting with account: {self.user}")
 
@@ -189,19 +191,18 @@ class IntervalReporter:
         price_trb_usd = trb_usd_median_feed.source.latest[0]
 
         tips, tb_reward = rewards
-        gas = 500000  # Taken from telliot-core contract write, TODO: optimize
         logger.info(
             f"""
             current tips: {tips} (half will be burned)
             current tb_reward: {tb_reward}
-            gas: {gas}
+            gas: {self.gas}
             gas_price_gwei: {gas_price_gwei}
             """
         )
 
         revenue = tb_reward + tips
         rev_usd = revenue / 1e18 * price_trb_usd
-        costs = gas * gas_price_gwei
+        costs = self.gas * gas_price_gwei
         costs_usd = costs / 1e9 * price_eth_usd
         profit_usd = rev_usd - costs_usd
         logger.info(f"Estimated profit: ${round(profit_usd, 2)}")

--- a/src/telliot_feed_examples/utils/contract.py
+++ b/src/telliot_feed_examples/utils/contract.py
@@ -1,9 +1,9 @@
 """Helper functions for TellorX contracts."""
+from typing import Tuple
+
 from telliot_core.contract.contract import Contract
 from telliot_core.directory.tellorx import tellor_directory
 from telliot_core.model.endpoints import RPCEndpoint
-
-from typing import Tuple
 
 
 def get_tellor_contracts(

--- a/src/telliot_feed_examples/utils/contract.py
+++ b/src/telliot_feed_examples/utils/contract.py
@@ -1,0 +1,34 @@
+"""Helper functions for TellorX contracts."""
+from telliot_core.contract.contract import Contract
+from telliot_core.directory.tellorx import tellor_directory
+from telliot_core.model.endpoints import RPCEndpoint
+
+from typing import Tuple
+
+
+def get_tellor_contracts(
+    private_key: str, chain_id: int, endpoint: RPCEndpoint
+) -> Tuple[Contract, Contract]:
+    """Get Contract objects per telliot configuration and
+    CLI flag options."""
+    endpoint.connect()
+
+    tellor_oracle = tellor_directory.find(chain_id=chain_id, name="oracle")[0]
+    oracle = Contract(
+        address=tellor_oracle.address,
+        abi=tellor_oracle.abi,
+        node=endpoint,
+        private_key=private_key,
+    )
+    oracle.connect()
+
+    tellor_master = tellor_directory.find(chain_id=chain_id, name="master")[0]
+    master = Contract(
+        address=tellor_master.address,
+        abi=tellor_master.abi,
+        node=endpoint,
+        private_key=private_key,
+    )
+    master.connect()
+
+    return master, oracle

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -18,6 +18,26 @@ def test_cmd_report():
     assert expected in result.output
 
 
+def test_custom_gas_flag():
+    """Test using a custom gas."""
+    # Test incorrect command invocation
+    runner = CliRunner()
+    result = runner.invoke(cli, ["-lid", "1", "report", "--ges"])
+
+    assert result.exit_code == 2
+
+    expected = "Error: No such option: --ges (Possible options: --gas, -gps)"
+    assert expected in result.output
+
+    # Test incorrect type
+    result = runner.invoke(cli, ["-lid", "1", "report", "-g", "blah"])
+
+    assert result.exit_code == 2
+
+    expected = "Error: Invalid value for '--gas' / '-g': 'blah' is not a valid integer."
+    assert expected in result.output
+
+
 def test_cmd_tip():
     """Test CLI tip command"""
     runner = CliRunner()

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -34,7 +34,9 @@ def test_custom_gas_flag():
 
     assert result.exit_code == 2
 
-    expected = "Error: Invalid value for '--gas-limit' / '-gl': 'blah' is not a valid integer."
+    expected = (
+        "Error: Invalid value for '--gas-limit' / '-gl': 'blah' is not a valid integer."
+    )
     assert expected in result.output
 
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -22,19 +22,19 @@ def test_custom_gas_flag():
     """Test using a custom gas."""
     # Test incorrect command invocation
     runner = CliRunner()
-    result = runner.invoke(cli, ["-lid", "1", "report", "--ges"])
+    result = runner.invoke(cli, ["-lid", "1", "--ges-limit", "report"])
 
     assert result.exit_code == 2
 
-    expected = "Error: No such option: --ges (Possible options: --gas, -gps)"
+    expected = "Error: No such option: --ges-limit Did you mean --gas-limit?"
     assert expected in result.output
 
     # Test incorrect type
-    result = runner.invoke(cli, ["-lid", "1", "report", "-g", "blah"])
+    result = runner.invoke(cli, ["-lid", "1", "-gl", "blah", "report"])
 
     assert result.exit_code == 2
 
-    expected = "Error: Invalid value for '--gas' / '-g': 'blah' is not a valid integer."
+    expected = "Error: Invalid value for '--gas-limit' / '-gl': 'blah' is not a valid integer."
     assert expected in result.output
 
 


### PR DESCRIPTION
Adds custom gas flag option (`--gas/-g`).
Changes the rewards units of the log message to TRB.
Removes confusing log message about tips being burned.
Moves contracts helper function to utilities.

Gas flag option usage/example:
```
user:~$ telliot-examples -lid 1 report -g 350000 -p 2
Reporting legacy ID: 1
Current chain ID: 4
Lower bound for expected percent profit: 2.0%
Selected gas price speed: fast
Gas: 350000
...
```

Example updated rewards log message:
```
2021-12-07 05:45:45,240 - telliot_feed_examples.reporters.interval - INFO -
            current tips: 5e-06 TRB
            current tb_reward: 2.6066666666666665 TRB
            gas: 350000
            gas_price_gwei: 97
```