### PR TITLE
Make help commands more user-friendly

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,7 +20,7 @@ Usage: telliot-examples [OPTIONS] COMMAND [ARGS]...
 Options:
   -pk, --private-key TEXT   override the config's private key
   -cid, --chain-id INTEGER  override the config's chain ID
-  -lid, --legacy-id TEXT    report to a legacy ID  [required]
+  -rpc, --rpc-url TEXT      override the config RPC url
   --help                    Show this message and exit.
 
 Commands:
@@ -48,9 +48,13 @@ Usage: telliot-examples report [OPTIONS]
   Report values to Tellor oracle
 
 Options:
-  -mgp, --max-gas-price INTEGER   maximum gas price used by reporter
+  -lid, --legacy-id TEXT          report to a legacy ID  [required]
+  -gl, --gas-limit INTEGER        use custom gas limit
+  -mgp, --max-gas-price INTEGER   maximum gas price used by eth gas station
   -gps, --gas-price-speed [safeLow|average|fast|fastest]
                                   gas price speed for eth gas station API
+  -gp, --gas-price INTEGER        use custom gas price (overrides eth gas
+                                  station estimate)
   -p, --profit FLOAT              lower threshold (inclusive) for expected
                                   percent profit
   --submit-once / --submit-continuous

--- a/src/telliot_feed_examples/cli.py
+++ b/src/telliot_feed_examples/cli.py
@@ -52,6 +52,7 @@ cfg = TelliotConfig()
     required=True,
     nargs=1,
     type=str,
+    default=1,  # ETH/USD spot price
 )
 @click.option(
     "--gas-limit",

--- a/src/telliot_feed_examples/cli.py
+++ b/src/telliot_feed_examples/cli.py
@@ -45,15 +45,6 @@ cfg = TelliotConfig()
     type=int,
 )
 @click.option(
-    "--gas-limit",
-    "-gl",
-    "gas_limit",
-    help="use custom gas limit",
-    nargs=1,
-    type=int,
-    default=500000,
-)
-@click.option(
     "--rpc-url",
     "-rpc",
     "override_rpc_url",
@@ -67,14 +58,12 @@ def cli(
     ctx: Context,
     private_key: str,
     chain_id: int,
-    gas_limit: int,
     override_rpc_url: str,
 ) -> None:
     """Telliot command line interface"""
     ctx.ensure_object(dict)
     ctx.obj["PRIVATE_KEY"] = private_key
     ctx.obj["CHAIN_ID"] = chain_id
-    ctx.obj["GAS_LIMIT"] = gas_limit
     ctx.obj["RPC_URL"] = override_rpc_url
 
 
@@ -89,6 +78,15 @@ def cli(
     nargs=1,
     type=str,
     default=1,  # ETH/USD spot price
+)
+@click.option(
+    "--gas-limit",
+    "-gl",
+    "gas_limit",
+    help="use custom gas limit",
+    nargs=1,
+    type=int,
+    default=350000,
 )
 @click.option(
     "--max-gas-price",
@@ -134,6 +132,7 @@ def cli(
 def report(
     ctx: Context,
     legacy_id: str,
+    gas_limit: int,
     gas_price: int,
     max_gas_price: int,
     gas_price_speed: str,
@@ -150,7 +149,6 @@ def report(
 
     private_key = ctx.obj["PRIVATE_KEY"]
     chain_id = ctx.obj["CHAIN_ID"]
-    gas_limit = ctx.obj["GAS_LIMIT"]
     override_rpc_url = ctx.obj["RPC_URL"]
     cfg.main.private_key = private_key
     cfg.main.chain_id = chain_id
@@ -183,7 +181,6 @@ def report(
 
     click.echo(f"Gas Limit: {gas_limit}")
 
-    # return
     master, oracle = get_tellor_contracts(
         private_key=private_key, endpoint=endpoint, chain_id=cfg.main.chain_id
     )

--- a/src/telliot_feed_examples/cli.py
+++ b/src/telliot_feed_examples/cli.py
@@ -45,16 +45,6 @@ cfg = TelliotConfig()
     type=int,
 )
 @click.option(
-    "--legacy-id",
-    "-lid",
-    "legacy_id",
-    help="report to a legacy ID",
-    required=True,
-    nargs=1,
-    type=str,
-    default=1,  # ETH/USD spot price
-)
-@click.option(
     "--gas-limit",
     "-gl",
     "gas_limit",
@@ -64,26 +54,26 @@ cfg = TelliotConfig()
     default=500000,
 )
 @click.pass_context
-def cli(
-    ctx: Context, private_key: str, chain_id: int, legacy_id: str, gas_limit: int
-) -> None:
+def cli(ctx: Context, private_key: str, chain_id: int, gas_limit: int) -> None:
     """Telliot command line interface"""
-    # Ensure valid legacy id
-    if legacy_id not in LEGACY_DATAFEEDS:
-        click.echo(
-            f"Invalid legacy ID. Valid choices: {', '.join(list(LEGACY_DATAFEEDS))}"
-        )
-        return
-
     ctx.ensure_object(dict)
     ctx.obj["PRIVATE_KEY"] = private_key
     ctx.obj["CHAIN_ID"] = chain_id
-    ctx.obj["LEGACY_ID"] = legacy_id
     ctx.obj["GAS_LIMIT"] = gas_limit
 
 
 # Report subcommand options
 @cli.command()
+@click.option(
+    "--legacy-id",
+    "-lid",
+    "legacy_id",
+    help="report to a legacy ID",
+    required=True,
+    nargs=1,
+    type=str,
+    default=1,  # ETH/USD spot price
+)
 @click.option(
     "--max-gas-price",
     "-mgp",
@@ -127,6 +117,7 @@ def cli(
 @click.pass_context
 def report(
     ctx: Context,
+    legacy_id: str,
     gas_price: int,
     max_gas_price: int,
     gas_price_speed: str,
@@ -134,10 +125,15 @@ def report(
     profit_percent: float,
 ) -> None:
     """Report values to Tellor oracle"""
+    # Ensure valid legacy id
+    if legacy_id not in LEGACY_DATAFEEDS:
+        click.echo(
+            f"Invalid legacy ID. Valid choices: {', '.join(list(LEGACY_DATAFEEDS))}"
+        )
+        return
 
     private_key = ctx.obj["PRIVATE_KEY"]
     chain_id = ctx.obj["CHAIN_ID"]
-    legacy_id = ctx.obj["LEGACY_ID"]
     gas_limit = ctx.obj["GAS_LIMIT"]
     cfg.main.private_key = private_key
     cfg.main.chain_id = chain_id
@@ -193,6 +189,16 @@ def report(
 
 @cli.command()
 @click.option(
+    "--legacy-id",
+    "-lid",
+    "legacy_id",
+    help="report to a legacy ID",
+    required=True,
+    nargs=1,
+    type=str,
+    default=1,  # ETH/USD spot price
+)
+@click.option(
     "--amount-trb",
     "-trb",
     "amount_trb",
@@ -204,10 +210,16 @@ def report(
 @click.pass_context
 def tip(
     ctx: Context,
+    legacy_id: str,
     amount_trb: float,
 ) -> None:
     """Tip TRB for a selected query ID"""
-    legacy_id = ctx.obj["LEGACY_ID"]
+    # Ensure valid legacy id
+    if legacy_id not in LEGACY_DATAFEEDS:
+        click.echo(
+            f"Invalid legacy ID. Valid choices: {', '.join(list(LEGACY_DATAFEEDS))}"
+        )
+        return
 
     click.echo(f"Tipping {amount_trb} TRB for legacy ID {legacy_id}.")
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -10,9 +10,9 @@ from telliot_feed_examples.feeds import LEGACY_DATAFEEDS
 def test_cmd_report():
     """Test report command."""
     runner = CliRunner()
-    result = runner.invoke(cli, ["--legacy-id", "1234", "report"])
+    result = runner.invoke(cli, ["report", "--legacy-id", "1234"])
 
-    assert result.exit_code == 1
+    assert result.exit_code == 0
 
     expected = f"Invalid legacy ID. Valid choices: {', '.join(list(LEGACY_DATAFEEDS))}"
     assert expected in result.output
@@ -22,7 +22,7 @@ def test_custom_gas_flag():
     """Test using a custom gas."""
     # Test incorrect command invocation
     runner = CliRunner()
-    result = runner.invoke(cli, ["-lid", "1", "--ges-limit", "report"])
+    result = runner.invoke(cli, ["--ges-limit", "report"])
 
     assert result.exit_code == 2
 
@@ -30,7 +30,7 @@ def test_custom_gas_flag():
     assert expected in result.output
 
     # Test incorrect type
-    result = runner.invoke(cli, ["-lid", "1", "-gl", "blah", "report"])
+    result = runner.invoke(cli, ["-gl", "blah", "report"])
 
     assert result.exit_code == 2
 
@@ -44,7 +44,7 @@ def test_cmd_tip():
     """Test CLI tip command"""
     runner = CliRunner()
     trb = "0.00001"
-    result = runner.invoke(cli, ["-lid", "1", "tip", "--amount-usd", trb])
+    result = runner.invoke(cli, ["tip", "--amount-usd", trb])
 
     expected = "Error: No such option: --amount-usd Did you mean --amount-trb?"
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -22,7 +22,7 @@ def test_custom_gas_flag():
     """Test using a custom gas."""
     # Test incorrect command invocation
     runner = CliRunner()
-    result = runner.invoke(cli, ["--ges-limit", "report"])
+    result = runner.invoke(cli, ["report", "--ges-limit", "250000"])
 
     assert result.exit_code == 2
 
@@ -30,7 +30,7 @@ def test_custom_gas_flag():
     assert expected in result.output
 
     # Test incorrect type
-    result = runner.invoke(cli, ["-gl", "blah", "report"])
+    result = runner.invoke(cli, ["report", "-gl", "blah"])
 
     assert result.exit_code == 2
 
@@ -57,8 +57,6 @@ def test_rpc_override():
     result = runner.invoke(
         cli,
         [
-            "-lid",
-            "1",
             "--rpc-ur",
             "wss://rinkeby.infura.io/ws/v3/1a09c4705f114af2997548dd901d655b",
             "report",
@@ -74,8 +72,6 @@ def test_rpc_override():
     result = runner.invoke(
         cli,
         [
-            "-lid",
-            "1",
             "--rpc-url",
             "wss://goerli.infura.io/ws/v3/1a09c4705f114af2997548dd901d655b",
             "report",


### PR DESCRIPTION
Adds default value for legacy id flag option, so help command can be used intuitively:
```
telliot-examples report --help
```
This threw an error before this change because legacy id flag was required.