### PR TITLE
Pass gas limit param to submitValue oracle write

### DIFF
--- a/src/telliot_feed_examples/reporters/interval.py
+++ b/src/telliot_feed_examples/reporters/interval.py
@@ -308,6 +308,7 @@ class IntervalReporter:
         tx_receipt, status = await self.oracle.write_with_retry(
             func_name="submitValue",
             gas_price=gas_price_gwei,
+            gas_limit=self.gas_limit,
             extra_gas_price=extra_gas_price,
             retries=5,
             _queryId=query_id,

--- a/src/telliot_feed_examples/reporters/interval.py
+++ b/src/telliot_feed_examples/reporters/interval.py
@@ -87,6 +87,7 @@ class IntervalReporter:
 
             _, write_status = await self.master.write_with_retry(
                 func_name="depositStake",
+                gas_limit=350000,
                 gas_price=gas_price_gwei,
                 extra_gas_price=20,
                 retries=5,

--- a/src/telliot_feed_examples/utils/oracle_write.py
+++ b/src/telliot_feed_examples/utils/oracle_write.py
@@ -21,7 +21,7 @@ async def tip_query(
     reporters to report relevant data."""
     tx_receit, status = await oracle.write_with_retry(
         func_name="tipQuery",
-        gas_limit=350000,
+        # gas_limit=350000,  # TODO: uncomment when new core release
         gas_price=gas_price,
         extra_gas_price=20,
         retries=retries,

--- a/src/telliot_feed_examples/utils/oracle_write.py
+++ b/src/telliot_feed_examples/utils/oracle_write.py
@@ -21,6 +21,7 @@ async def tip_query(
     reporters to report relevant data."""
     tx_receit, status = await oracle.write_with_retry(
         func_name="tipQuery",
+        gas_limit=350000,
         gas_price=gas_price,
         extra_gas_price=20,
         retries=retries,


### PR DESCRIPTION
Adds the custom gas limit from user to the oracle write. Before it wasn't updating the hard-coded 500000. Example transaction using gas limit of 350k: https://rinkeby.etherscan.io/tx/0xadc531336f11ce10561bde2bbd618d2d667e594fd2c37d37416e0ffd288b32f4

Needs this PR merged to pass: https://github.com/tellor-io/telliot-core/pull/168