### PR TITLE
Fix stager tag option bug

### DIFF
--- a/src/telliot_feed_examples/cli.py
+++ b/src/telliot_feed_examples/cli.py
@@ -269,7 +269,7 @@ async def report(
 
         common_reporter_kwargs = {
             "endpoint": core.endpoint,
-            "private_key": core.get_default_staker().private_key,
+            "private_key": core.get_staker().private_key,
             "master": core.tellorx.master,
             "oracle": core.tellorx.oracle,
             "datafeed": chosen_feed,


### PR DESCRIPTION
Was passing `get_default_staker()` to reporter