### PR TITLE
Add better error message for insufficient TRB when attempting depositStake

### DIFF
--- a/src/telliot_feed_examples/reporters/interval.py
+++ b/src/telliot_feed_examples/reporters/interval.py
@@ -144,7 +144,7 @@ class IntervalReporter:
             _, write_status = await self.master.write_with_retry(
                 func_name="depositStake",
                 gas_limit=350000,
-                gas_price=gas_price_gwei,
+                legacy_gas_price=gas_price_gwei,
                 extra_gas_price=20,
                 retries=5,
             )
@@ -153,7 +153,9 @@ class IntervalReporter:
                 return True, status
             else:
                 status.error = (
-                    "Unable to stake deposit: " + write_status.error
+                    "Unable to stake deposit: "
+                    + write_status.error
+                    + f"Make sure {self.user} has enough ETH & TRB (100)"
                 )  # error won't be none # noqa: E501
                 logger.error(status.error)
                 status.e = write_status.e


### PR DESCRIPTION
Closes #82 
This PR depends on a bug fix in `telliot-core`: [#192](https://github.com/tellor-io/telliot-core/pull/192])

Example error message when you try to report with an account that has ETH, but no TRB:
```
2022-01-07 15:58:36,215 - telliot_feed_examples.reporters.interval - ERROR - Unable to stake deposit: Write attempt 1 failed, tx reverted
(https://rinkeby.etherscan.io/tx/0xd29fa32eb0ef94ec5edfc4770bccd8685347a95417179f044e0bb8dfb9369dcf): 
Make sure 0x735... has enough ETH & TRB (100)
```