### PR TITLE
Add option to select data feed using query tag

### DIFF
--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -39,18 +39,6 @@ def test_flag_staker_tag():
     assert expected in result.stdout
 
 
-def test_cmd_report():
-    """Test report command."""
-    runner = CliRunner()
-    result = runner.invoke(cli, ["-nfb", "report", "-lid", "1234"])
-
-    assert result.exception
-    assert result.exit_code == 2
-
-    expected = "Invalid value for '--legacy-id'"
-    assert expected in result.stdout
-
-
 def test_invalid_report_option_query_tag():
     """Test selecting datafeed using wrong query tag."""
     runner = CliRunner()

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -51,6 +51,18 @@ def test_cmd_report():
     assert expected in result.stdout
 
 
+def test_invalid_report_option_query_tag():
+    """Test selecting datafeed using wrong query tag."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["report", "-qt", "monero-usd-legacy"])
+
+    assert result.exception
+    assert result.exit_code == 2
+
+    expected = "Invalid value for '--query-tag' / '-qt'"
+    assert expected in result.stdout
+
+
 def test_custom_gas_flag():
     """Test using a custom gas."""
     # Test incorrect command invocation


### PR DESCRIPTION
Adds command line flag option (`--query-tag/-qt`) for selecting reporter datafeed by query tag (human-readable string).

Example usage:
```
telliot-examples -st staker9000 report -qt ohm-eth-spot
```

See supported query tags [here](https://github.com/tellor-io/dataSpecs/blob/main/catalog.md).

Closes #81 