### PR TITLE
Support manual reporting for Diva Protocol on Polygon

### DIFF
--- a/.github/workflows/py39.yml
+++ b/.github/workflows/py39.yml
@@ -19,6 +19,7 @@ jobs:
       TEST_SECRET: ${{ secrets.TEST_SECRET }}
       RAPID_KEY: ${{ secrets.TEST_RAPID_KEY }}
       ANYBLOCK_KEY: ${{ secrets.TEST_ANYBLOCK_KEY }}
+      INFURA_API_KEY: ${{ secrets.INFURA_API_KEY }}
 
     strategy:
       matrix:

--- a/src/telliot_feed_examples/cli.py
+++ b/src/telliot_feed_examples/cli.py
@@ -21,7 +21,7 @@ from telliot_feed_examples.feeds import CATALOG_FEEDS
 from telliot_feed_examples.reporters.flashbot import FlashbotsReporter
 from telliot_feed_examples.reporters.interval import IntervalReporter
 from telliot_feed_examples.reporters.tellorflex import PolygonReporter
-from telliot_feed_examples.utils.diva_protocol import fetch_diva_datafeed
+from telliot_feed_examples.utils.diva_protocol import assemble_diva_datafeed
 from telliot_feed_examples.utils.log import get_logger
 from telliot_feed_examples.utils.oracle_write import tip_query
 
@@ -322,7 +322,9 @@ async def report(
                 )
                 return
             # Generate datafeed
-            chosen_feed = fetch_diva_datafeed(diva_pool_id)
+            chosen_feed = await assemble_diva_datafeed(
+                pool_id=diva_pool_id, node=core.endpoint, account=account
+            )
         else:
             chosen_feed = None
 

--- a/src/telliot_feed_examples/cli.py
+++ b/src/telliot_feed_examples/cli.py
@@ -482,8 +482,8 @@ async def tip(
 async def settle(
     ctx: Context,
     pool_id: int,
-    legacy_gas_price: int,
     password: str,
+    legacy_gas_price: int = 100,
 ) -> None:
     """Settle a derivative pool in DIVA Protocol."""
 

--- a/src/telliot_feed_examples/cli.py
+++ b/src/telliot_feed_examples/cli.py
@@ -248,6 +248,14 @@ def cli(
     ),
     default="fast",
 )
+@click.option(
+    "--diva-option-id",
+    "-doid",
+    "diva_option_id",
+    help="option ID for Diva Protocol on Polygon",
+    nargs=1,
+    type=int,
+)
 @click.option("--submit-once/--submit-continuous", default=False)
 @click.option("-pswd", "--password", type=str)
 @click.pass_context

--- a/src/telliot_feed_examples/cli.py
+++ b/src/telliot_feed_examples/cli.py
@@ -63,6 +63,17 @@ def parse_profit_input(expected_profit: str) -> Optional[Union[str, float]]:
             return None
 
 
+def valid_diva_chain(chain_id: int) -> bool:
+    """Ensure given chain ID supports reporting Diva Protocol data."""
+    if chain_id not in POLYGON_CHAINS and chain_id != 3:  # Ropsten
+        print(
+            f"Current chain id ({chain_id}) not supported for"
+            " reporting Diva Protocol data."
+        )
+        return False
+    return True
+
+
 def print_reporter_settings(
     using_flashbots: bool,
     signature_address: str,
@@ -314,12 +325,7 @@ async def report(
         if query_tag is not None:
             chosen_feed = CATALOG_FEEDS[query_tag]
         elif diva_pool_id is not None:
-            # Ensure valid chain ID
-            if cid not in POLYGON_CHAINS and cid != 3:  # Ropsten
-                click.echo(
-                    f"Current chain id ({cid}) not supported for"
-                    " reporting Diva Protocol data."
-                )
+            if not valid_diva_chain(chain_id=cid):
                 return
             # Generate datafeed
             chosen_feed = await assemble_diva_datafeed(

--- a/src/telliot_feed_examples/cli.py
+++ b/src/telliot_feed_examples/cli.py
@@ -313,6 +313,13 @@ async def report(
             chosen_feed = CATALOG_FEEDS[query_tag]
         elif diva_option_id is not None:
             # Ensure valid chain ID
+            cid = core.config.main.chain_id
+            if cid not in POLYGON_CHAINS and cid != 3:  # Ropsten
+                click.echo(
+                    f"Current chain id ({cid}) not supported for"
+                    " reporting Diva Protocol data."
+                )
+                return
             # Generate datafeed
             chosen_feed = fetch_diva_datafeed(diva_option_id)
         else:

--- a/src/telliot_feed_examples/cli.py
+++ b/src/telliot_feed_examples/cli.py
@@ -21,8 +21,10 @@ from telliot_feed_examples.feeds import CATALOG_FEEDS
 from telliot_feed_examples.reporters.flashbot import FlashbotsReporter
 from telliot_feed_examples.reporters.interval import IntervalReporter
 from telliot_feed_examples.reporters.tellorflex import PolygonReporter
+from telliot_feed_examples.utils.diva_protocol import fetch_diva_datafeed
 from telliot_feed_examples.utils.log import get_logger
 from telliot_feed_examples.utils.oracle_write import tip_query
+
 
 logger = get_logger(__name__)
 
@@ -271,6 +273,7 @@ async def report(
     expected_profit: str,
     submit_once: bool,
     gas_price_speed: str,
+    diva_option_id: int,
     password: str,
 ) -> None:
     """Report values to Tellor oracle"""
@@ -308,6 +311,10 @@ async def report(
         # Use selected feed, or choose automatically
         if query_tag is not None:
             chosen_feed = CATALOG_FEEDS[query_tag]
+        elif diva_option_id is not None:
+            # Ensure valid chain ID
+            # Generate datafeed
+            chosen_feed = fetch_diva_datafeed(diva_option_id)
         else:
             chosen_feed = None
 

--- a/src/telliot_feed_examples/cli.py
+++ b/src/telliot_feed_examples/cli.py
@@ -308,12 +308,13 @@ async def report(
         else:
             sig_staker_address = ""  # type: ignore
 
+        cid = core.config.main.chain_id
+
         # Use selected feed, or choose automatically
         if query_tag is not None:
             chosen_feed = CATALOG_FEEDS[query_tag]
         elif diva_option_id is not None:
             # Ensure valid chain ID
-            cid = core.config.main.chain_id
             if cid not in POLYGON_CHAINS and cid != 3:  # Ropsten
                 click.echo(
                     f"Current chain id ({cid}) not supported for"
@@ -335,7 +336,7 @@ async def report(
             priority_fee=priority_fee,
             legacy_gas_price=legacy_gas_price,
             expected_profit=expected_profit,
-            chain_id=core.config.main.chain_id,
+            chain_id=cid,
             gas_price_speed=gas_price_speed,
         )
 
@@ -351,11 +352,11 @@ async def report(
             "priority_fee": priority_fee,
             "legacy_gas_price": legacy_gas_price,
             "gas_price_speed": gas_price_speed,
-            "chain_id": core.config.main.chain_id,
+            "chain_id": cid,
         }
 
         # Report to Polygon TellorFlex
-        if core.config.main.chain_id in POLYGON_CHAINS:
+        if core.config.main.chain_id in POLYGON_CHAINS or cid == 3:
             stake = get_stake_amount()
 
             tellorflex = core.get_tellorflex_contracts()

--- a/src/telliot_feed_examples/cli.py
+++ b/src/telliot_feed_examples/cli.py
@@ -251,10 +251,10 @@ def cli(
     default="fast",
 )
 @click.option(
-    "--diva-option-id",
-    "-doid",
-    "diva_option_id",
-    help="option ID for Diva Protocol on Polygon",
+    "--pool-id",
+    "-pid",
+    "diva_pool_id",
+    help="pool ID for Diva Protocol on Polygon",
     nargs=1,
     type=int,
 )
@@ -273,7 +273,7 @@ async def report(
     expected_profit: str,
     submit_once: bool,
     gas_price_speed: str,
-    diva_option_id: int,
+    diva_pool_id: int,
     password: str,
 ) -> None:
     """Report values to Tellor oracle"""
@@ -313,7 +313,7 @@ async def report(
         # Use selected feed, or choose automatically
         if query_tag is not None:
             chosen_feed = CATALOG_FEEDS[query_tag]
-        elif diva_option_id is not None:
+        elif diva_pool_id is not None:
             # Ensure valid chain ID
             if cid not in POLYGON_CHAINS and cid != 3:  # Ropsten
                 click.echo(
@@ -322,7 +322,7 @@ async def report(
                 )
                 return
             # Generate datafeed
-            chosen_feed = fetch_diva_datafeed(diva_option_id)
+            chosen_feed = fetch_diva_datafeed(diva_pool_id)
         else:
             chosen_feed = None
 

--- a/src/telliot_feed_examples/utils/diva_protocol.py
+++ b/src/telliot_feed_examples/utils/diva_protocol.py
@@ -1,13 +1,22 @@
 """Helper functions for reporting data for Diva Protocol."""
-from telliot_core.queries.diva_protocol import divaProtocolPolygon
-from telliot_feed_examples.feeds.eth_usd_feed import eth_usd_median_feed
 from telliot_core.api import DataFeed
+from telliot_core.queries.diva_protocol import divaProtocolPolygon
+
+from telliot_feed_examples.feeds.btc_usd_feed import btc_usd_median_feed
+from telliot_feed_examples.feeds.eth_usd_feed import eth_usd_median_feed
+
+
+DATAFEED_LOOKUP = {
+    "ETH/USD": eth_usd_median_feed,
+    "BTC/USD": btc_usd_median_feed,
+}
 
 
 def fetch_diva_datafeed(option_id: int) -> DataFeed[float]:
     """Returns datafeed using user input option ID and corresponding
     asset information."""
-    # TODO get feed based on asset
-    feed = eth_usd_median_feed
+    # TODO get asset from diva based on option_id
+    asset = "ETH/USD"
+    feed = DATAFEED_LOOKUP[asset]
     feed.query = divaProtocolPolygon(option_id)
     return feed

--- a/src/telliot_feed_examples/utils/diva_protocol.py
+++ b/src/telliot_feed_examples/utils/diva_protocol.py
@@ -12,11 +12,11 @@ DATAFEED_LOOKUP = {
 }
 
 
-def fetch_diva_datafeed(option_id: int) -> DataFeed[float]:
+def fetch_diva_datafeed(pool_id: int) -> DataFeed[float]:
     """Returns datafeed using user input option ID and corresponding
     asset information."""
-    # TODO get asset from diva based on option_id
+    # TODO get asset from diva based on pool_id
     asset = "ETH/USD"
     feed = DATAFEED_LOOKUP[asset]
-    feed.query = divaProtocolPolygon(option_id)
+    feed.query = divaProtocolPolygon(pool_id)
     return feed

--- a/src/telliot_feed_examples/utils/diva_protocol.py
+++ b/src/telliot_feed_examples/utils/diva_protocol.py
@@ -1,9 +1,18 @@
 """Helper functions for reporting data for Diva Protocol."""
+import logging
+from typing import Optional
+
+from chained_accounts import ChainedAccount
 from telliot_core.api import DataFeed
+from telliot_core.model.endpoints import RPCEndpoint
 from telliot_core.queries.diva_protocol import divaProtocolPolygon
+from telliot_core.tellor.tellorflex.diva import DivaProtocolContract
 
 from telliot_feed_examples.feeds.btc_usd_feed import btc_usd_median_feed
 from telliot_feed_examples.feeds.eth_usd_feed import eth_usd_median_feed
+
+
+logger = logging.getLogger(__name__)
 
 
 DATAFEED_LOOKUP = {
@@ -12,11 +21,27 @@ DATAFEED_LOOKUP = {
 }
 
 
-def fetch_diva_datafeed(pool_id: int) -> DataFeed[float]:
+async def assemble_diva_datafeed(
+    pool_id: int, node: RPCEndpoint, account: ChainedAccount
+) -> Optional[DataFeed[float]]:
     """Returns datafeed using user input option ID and corresponding
     asset information."""
-    # TODO get asset from diva based on pool_id
-    asset = "ETH/USD"
+
+    diva = DivaProtocolContract(node, account)
+    diva.connect()
+
+    params = await diva.get_pool_parameters(pool_id)
+    if params is None:
+        logger.error("Could not assemble diva datafeed: error getting pool params.")
+        return None
+
+    asset = params[0]
     feed = DATAFEED_LOOKUP[asset]
+    if feed is None:
+        logger.error(
+            "Could not assemble diva datafeed: error"
+            f"getting feed based on asset: {asset}"
+        )
     feed.query = divaProtocolPolygon(pool_id)
+
     return feed

--- a/src/telliot_feed_examples/utils/diva_protocol.py
+++ b/src/telliot_feed_examples/utils/diva_protocol.py
@@ -1,0 +1,13 @@
+"""Helper functions for reporting data for Diva Protocol."""
+from telliot_core.queries.diva_protocol import divaProtocolPolygon
+from telliot_feed_examples.feeds.eth_usd_feed import eth_usd_median_feed
+from telliot_core.api import DataFeed
+
+
+def fetch_diva_datafeed(option_id: int) -> DataFeed[float]:
+    """Returns datafeed using user input option ID and corresponding
+    asset information."""
+    # TODO get feed based on asset
+    feed = eth_usd_median_feed
+    feed.query = divaProtocolPolygon(option_id)
+    return feed

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -73,6 +73,15 @@ def test_custom_gas_flag():
     assert expected in result.output
 
 
+def test_diva_protocol_invalid_chain():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--test_config", "report", "-pid", "100"])
+
+    expected = "Current chain id (4) not supported for reporting Diva Protocol data."
+
+    assert expected in result.output
+
+
 def test_cmd_tip():
     """Test CLI tip command"""
     runner = CliRunner()

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -101,3 +101,13 @@ def test_get_stake_amount(monkeypatch):
     with pytest.raises(Abort):
         monkeypatch.setattr("sys.stdin", StringIO("asdf\n"))
         _ = get_stake_amount()
+
+
+def test_cmd_settle():
+    """Test CLI settle DIVA pool command"""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--test_config", "settle", "--pool-id", "a;lsdkfj;ak"])
+
+    expected = "Invalid value"
+
+    assert expected in result.output

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -10,6 +10,7 @@ from click.testing import CliRunner
 from telliot_feed_examples.cli import cli
 from telliot_feed_examples.cli import get_stake_amount
 from telliot_feed_examples.cli import parse_profit_input
+from telliot_feed_examples.cli import valid_diva_chain
 
 
 def test_parse_profit_input():
@@ -74,12 +75,9 @@ def test_custom_gas_flag():
 
 
 def test_diva_protocol_invalid_chain():
-    runner = CliRunner()
-    result = runner.invoke(cli, ["--test_config", "report", "-pid", "100"])
+    valid = valid_diva_chain(chain_id=1)
 
-    expected = "Current chain id (4) not supported for reporting Diva Protocol data."
-
-    assert expected in result.output
+    assert not valid
 
 
 def test_cmd_tip():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,35 @@ def mumbai_cfg():
     return cfg
 
 
+@pytest.fixture(scope="session", autouse=True)
+def ropsten_cfg():
+    """Return a test telliot configuration for use on polygon-mumbai
+
+    If environment variables are defined, they will override the values in config files
+    """
+    cfg = TelliotConfig()
+
+    # Override configuration for ropsten testnet
+    cfg.main.chain_id = 3
+
+    endpt = cfg.get_endpoint()
+    if "INFURA_API_KEY" in endpt.url:
+        endpt.url = f'wss://ropsten.infura.io/ws/v3/{os.environ["INFURA_API_KEY"]}'
+
+    accounts = find_accounts(chain_id=3)
+    if not accounts:
+        # Create a test account using PRIVATE_KEY defined on github.
+        key = os.getenv("PRIVATE_KEY", None)
+        if key:
+            ChainedAccount.add(
+                "git-ropsten-key", chains=3, key=os.environ["PRIVATE_KEY"], password=""
+            )
+        else:
+            raise Exception("Need a mumbai account")
+
+    return cfg
+
+
 @pytest.fixture(scope="session")
 def bad_source():
     """Used for testing no updated value for datafeeds."""

--- a/tests/utils/test_diva.py
+++ b/tests/utils/test_diva.py
@@ -1,0 +1,18 @@
+import pytest
+
+from telliot_core.apps.core import TelliotCore
+from telliot_core.api import DataFeed
+from telliot_core.queries.diva_protocol import divaProtocolPolygon
+
+from telliot_feed_examples.utils.diva_protocol import assemble_diva_datafeed
+
+
+@pytest.mark.asyncio
+async def test_assemble_diva_datafeed(ropsten_cfg) -> None:
+    async with TelliotCore(config=ropsten_cfg) as core:
+        account = core.get_account()
+        feed = await assemble_diva_datafeed(pool_id=159, node=core.endpoint, account=account)
+
+        assert isinstance(feed, DataFeed)
+        assert isinstance(feed.query, divaProtocolPolygon)
+        assert feed.source.asset == "btc"

--- a/tests/utils/test_diva.py
+++ b/tests/utils/test_diva.py
@@ -1,7 +1,6 @@
 import pytest
-
-from telliot_core.apps.core import TelliotCore
 from telliot_core.api import DataFeed
+from telliot_core.apps.core import TelliotCore
 from telliot_core.queries.diva_protocol import divaProtocolPolygon
 
 from telliot_feed_examples.utils.diva_protocol import assemble_diva_datafeed
@@ -11,7 +10,9 @@ from telliot_feed_examples.utils.diva_protocol import assemble_diva_datafeed
 async def test_assemble_diva_datafeed(ropsten_cfg) -> None:
     async with TelliotCore(config=ropsten_cfg) as core:
         account = core.get_account()
-        feed = await assemble_diva_datafeed(pool_id=159, node=core.endpoint, account=account)
+        feed = await assemble_diva_datafeed(
+            pool_id=159, node=core.endpoint, account=account
+        )
 
         assert isinstance(feed, DataFeed)
         assert isinstance(feed.query, divaProtocolPolygon)


### PR DESCRIPTION
Closes #114 

Reporting data for Diva Protocol:
```
telliot-examples -a fakename report --pool-id 147
```

Closing the pool:
```
telliot-examples -a fake name settle -pid 147
```

- [x] enter pool ID via CLI option flag
- [x] able to report on Ropsten testnet (tellor playground)
- [x] able to report on Polygon (tellorFlex)
- [x] makes new instance of diva query based on user input pool ID
- [x] fetches asset info linked to pool ID by calling diva contract function (pool params)
- [x] gets sources based on asset info found ^ and passes new data feed w/ those sources & query to reporter
- [x] test for fetching diva data feed
- [x] test for invalid chain id cli output
- [x] manual cli command for calling `setRefVal()` & test