### PR TITLE
stripped API key + tested feed

### DIFF
--- a/src/telliot_feed_examples/feeds/gas_price_oracle_feed.py
+++ b/src/telliot_feed_examples/feeds/gas_price_oracle_feed.py
@@ -16,5 +16,5 @@ chain_id = 1
 timestamp = 1648771200  # april 1, 2022 unix time
 
 gas_price_oracle_feed = DataFeed(
-    query=GasPriceOracle(chain_id, timestamp),
-    source=GasPriceOracleSource())
+    query=GasPriceOracle(chain_id, timestamp), source=GasPriceOracleSource()
+)

--- a/src/telliot_feed_examples/feeds/gas_price_oracle_feed.py
+++ b/src/telliot_feed_examples/feeds/gas_price_oracle_feed.py
@@ -1,0 +1,20 @@
+"""Datafeed for reporting responses to the GasPriceOracle query type.
+
+This GasPriceOracle data feed example queries the
+gas price on Mainnet Ethereum on April 1, 2022
+
+More info:
+https://github.com/tellor-io/dataSpecs/blob/main/types/GasPriceOracle.md
+
+ """
+from telliot_core.datafeed import DataFeed
+from telliot_core.queries.gas_price_oracle import GasPriceOracle
+
+from telliot_feed_examples.sources.gas_price_oracle import GasPriceOracleSource
+
+chain_id = 1
+timestamp = 1648771200  # april 1, 2022 unix time
+
+gas_price_oracle_feed = DataFeed(
+    query=GasPriceOracle(chain_id, timestamp),
+    source=GasPriceOracleSource())

--- a/src/telliot_feed_examples/sources/gas_price_oracle.py
+++ b/src/telliot_feed_examples/sources/gas_price_oracle.py
@@ -57,8 +57,6 @@ class GasPriceOracleSource(DataSource[str]):
             f"&to={int(timestamp) + 100}"
         )
 
-        print(url)
-
         with requests.Session() as s:
             s.mount("https://", adapter)
             try:

--- a/src/telliot_feed_examples/sources/gas_price_oracle.py
+++ b/src/telliot_feed_examples/sources/gas_price_oracle.py
@@ -110,11 +110,7 @@ class GasPriceOracleSource(DataSource[str]):
             return None, None
         except ValueError:
             logger.error(
-                """
-                Unable to calculate median
-                gas price from GasPriceOracle
-                source JSON
-                """
+                "Unable to calculate median gas price from GasPriceOracle source JSON"
             )
             return None, None
         gas_prices.sort()

--- a/tests/feeds/test_gas_price_oracle_feed.py
+++ b/tests/feeds/test_gas_price_oracle_feed.py
@@ -8,7 +8,6 @@ from telliot_feed_examples.feeds.gas_price_oracle_feed import timestamp
 
 
 @pytest.mark.asyncio
-# @pytest.mark.skip
 async def test_fetch_new_datapoint():
     """Retrieve historical gas price data from source."""
 

--- a/tests/feeds/test_gas_price_oracle_feed.py
+++ b/tests/feeds/test_gas_price_oracle_feed.py
@@ -1,19 +1,17 @@
 from datetime import datetime
-from time import time
 
 import pytest
-
-from telliot_feed_examples.sources.gas_price_oracle import GasPriceOracleSource
+from telliot_feed_examples.feeds.gas_price_oracle_feed import gas_price_oracle_feed, timestamp, chain_id
 
 
 @pytest.mark.asyncio
+# @pytest.mark.skip
 async def test_fetch_new_datapoint():
     """Retrieve historical gas price data from source."""
 
-    timestamp = time() - 2000
-    chain_id = 1
-
-    v, t = await GasPriceOracleSource().fetch_new_datapoint(timestamp, chain_id)
+    v, t = await gas_price_oracle_feed.source.fetch_new_datapoint(
+        timestamp, chain_id
+    )
 
     assert v is not None and t is not None
     assert isinstance(v, float)

--- a/tests/feeds/test_gas_price_oracle_feed.py
+++ b/tests/feeds/test_gas_price_oracle_feed.py
@@ -1,7 +1,10 @@
 from datetime import datetime
 
 import pytest
-from telliot_feed_examples.feeds.gas_price_oracle_feed import gas_price_oracle_feed, timestamp, chain_id
+
+from telliot_feed_examples.feeds.gas_price_oracle_feed import chain_id
+from telliot_feed_examples.feeds.gas_price_oracle_feed import gas_price_oracle_feed
+from telliot_feed_examples.feeds.gas_price_oracle_feed import timestamp
 
 
 @pytest.mark.asyncio
@@ -9,9 +12,7 @@ from telliot_feed_examples.feeds.gas_price_oracle_feed import gas_price_oracle_f
 async def test_fetch_new_datapoint():
     """Retrieve historical gas price data from source."""
 
-    v, t = await gas_price_oracle_feed.source.fetch_new_datapoint(
-        timestamp, chain_id
-    )
+    v, t = await gas_price_oracle_feed.source.fetch_new_datapoint(timestamp, chain_id)
 
     assert v is not None and t is not None
     assert isinstance(v, float)


### PR DESCRIPTION
For the GasPriceOracle DataFeed and DataSource, I've removed the `api_key` as a requirement for querying the owlracle gas price API, as it has a keyless free tier.