### PR TITLE
catch bad requests in WebPriceService class

### DIFF
--- a/src/telliot_feed_examples/feeds/__init__.py
+++ b/src/telliot_feed_examples/feeds/__init__.py
@@ -4,6 +4,7 @@ from telliot_feed_examples.feeds.btc_usd_feed import btc_usd_median_feed
 from telliot_feed_examples.feeds.dai_usd_feed import dai_usd_median_feed
 from telliot_feed_examples.feeds.eth_jpy_feed import eth_jpy_median_feed
 from telliot_feed_examples.feeds.eth_usd_feed import eth_usd_median_feed
+from telliot_feed_examples.feeds.gas_price_oracle_feed import gas_price_oracle_feed
 from telliot_feed_examples.feeds.idle_usd_feed import idle_usd_median_feed
 from telliot_feed_examples.feeds.matic_usd_feed import matic_usd_median_feed
 from telliot_feed_examples.feeds.mkr_usd_feed import mkr_usd_median_feed
@@ -15,7 +16,6 @@ from telliot_feed_examples.feeds.trb_usd_feed import trb_usd_median_feed
 from telliot_feed_examples.feeds.usdc_usd_feed import usdc_usd_median_feed
 from telliot_feed_examples.feeds.uspce_feed import uspce_feed
 from telliot_feed_examples.feeds.vesq import vsq_usd_median_feed
-from telliot_feed_examples.feeds.gas_price_oracle_feed import gas_price_oracle_feed
 
 
 # Supported legacy feeds

--- a/src/telliot_feed_examples/feeds/__init__.py
+++ b/src/telliot_feed_examples/feeds/__init__.py
@@ -15,6 +15,7 @@ from telliot_feed_examples.feeds.trb_usd_feed import trb_usd_median_feed
 from telliot_feed_examples.feeds.usdc_usd_feed import usdc_usd_median_feed
 from telliot_feed_examples.feeds.uspce_feed import uspce_feed
 from telliot_feed_examples.feeds.vesq import vsq_usd_median_feed
+from telliot_feed_examples.feeds.gas_price_oracle_feed import gas_price_oracle_feed
 
 
 # Supported legacy feeds
@@ -45,4 +46,5 @@ CATALOG_FEEDS = {
     "matic-usd-spot": matic_usd_median_feed,
     "usdc-usd-spot": usdc_usd_median_feed,
     "morphware-v1": morphware_v1_feed,
+    "gas-price-oracle-example": gas_price_oracle_feed,
 }

--- a/src/telliot_feed_examples/feeds/gas_price_oracle_feed.py
+++ b/src/telliot_feed_examples/feeds/gas_price_oracle_feed.py
@@ -16,5 +16,5 @@ chain_id = 1
 timestamp = 1648771200  # april 1, 2022 unix time
 
 gas_price_oracle_feed = DataFeed(
-    query=GasPriceOracle(chain_id, timestamp), source=GasPriceOracleSource()
+    query=GasPriceOracle(chain_id, timestamp), source=GasPriceOracleSource(chain_id=chain_id, timestamp=timestamp)
 )

--- a/src/telliot_feed_examples/feeds/gas_price_oracle_feed.py
+++ b/src/telliot_feed_examples/feeds/gas_price_oracle_feed.py
@@ -16,5 +16,6 @@ chain_id = 1
 timestamp = 1648771200  # april 1, 2022 unix time
 
 gas_price_oracle_feed = DataFeed(
-    query=GasPriceOracle(chain_id, timestamp), source=GasPriceOracleSource(chain_id=chain_id, timestamp=timestamp)
+    query=GasPriceOracle(chain_id, timestamp),
+    source=GasPriceOracleSource(chain_id=chain_id, timestamp=timestamp),
 )

--- a/src/telliot_feed_examples/sources/gas_price_oracle.py
+++ b/src/telliot_feed_examples/sources/gas_price_oracle.py
@@ -1,4 +1,3 @@
-import time
 from dataclasses import dataclass
 from time import time
 from typing import Optional

--- a/src/telliot_feed_examples/sources/gas_price_oracle.py
+++ b/src/telliot_feed_examples/sources/gas_price_oracle.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from dataclasses import field
+from time import time
 from typing import Dict
 from typing import Optional
 
@@ -29,8 +30,15 @@ adapter = HTTPAdapter(max_retries=retry_strategy)
 class GasPriceOracleSource(DataSource[str]):
     """DataSource for GasPriceOracle expected response data."""
 
-    networks: Dict[int, str] = field(
-        default_factory=lambda: {
+    chain_id: int = 1
+    timestamp: int = time()
+
+    async def fetch_historical_gas_price(
+        self,
+    ) -> Optional[Response]:
+        """Fetches historical gas price data from Owlracle API."""
+
+        networks = {
             1: "eth",
             56: "bsc",
             43114: "avax",
@@ -42,19 +50,13 @@ class GasPriceOracleSource(DataSource[str]):
             1285: "movr",
             122: "fuse",
         }
-    )
-
-    async def fetch_historical_gas_price(
-        self, timestamp: int, chain_id: int
-    ) -> Optional[Response]:
-        """Fetches historical gas price data from Owlracle API."""
 
         url = (
             f"https://owlracle.info/"
-            f"{self.networks[chain_id]}"
+            f"{networks[self.chain_id]}"
             "/history?"
-            f"from={int(timestamp)}"
-            f"&to={int(timestamp) + 100}"
+            f"from={int(self.timestamp)}"
+            f"&to={int(self.timestamp) + 100}"
         )
 
         with requests.Session() as s:
@@ -67,16 +69,14 @@ class GasPriceOracleSource(DataSource[str]):
                 return None
 
     async def fetch_new_datapoint(
-        self, timestamp: int, chain_id: int
+        self,
     ) -> Optional[DataPoint[list[str]]]:
         """Retrieves historical gas prices from Owlracle API.
 
         Returns:
             float gas price in gwei, typically with one decimal place
         """
-        rsp = await self.fetch_historical_gas_price(
-            timestamp=timestamp, chain_id=chain_id
-        )
+        rsp = await self.fetch_historical_gas_price()
         if rsp is None:
             logger.warning("No response from GasPriceOracle API")
             return None, None

--- a/src/telliot_feed_examples/sources/gas_price_oracle.py
+++ b/src/telliot_feed_examples/sources/gas_price_oracle.py
@@ -29,7 +29,7 @@ class GasPriceOracleSource(DataSource[str]):
     """DataSource for GasPriceOracle expected response data."""
 
     chain_id: int = 1
-    timestamp: int = time()
+    timestamp: int = int(time())
 
     async def fetch_historical_gas_price(
         self,

--- a/src/telliot_feed_examples/sources/gas_price_oracle.py
+++ b/src/telliot_feed_examples/sources/gas_price_oracle.py
@@ -1,7 +1,5 @@
 from dataclasses import dataclass
-from dataclasses import field
 from time import time
-from typing import Dict
 from typing import Optional
 
 import requests

--- a/src/telliot_feed_examples/sources/price/spot/gemini.py
+++ b/src/telliot_feed_examples/sources/price/spot/gemini.py
@@ -3,7 +3,7 @@ from dataclasses import field
 from typing import Any
 from typing import Dict
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from telliot_core.dtypes.datapoint import datetime_now_utc
 from telliot_core.dtypes.datapoint import OptionalDataPoint
 from telliot_core.pricing.price_service import WebPriceService
@@ -57,7 +57,10 @@ class GeminiSpotPriceService(WebPriceService):
             return None, None
 
         else:
-            r = GeminiPriceResponse.parse_obj(d["response"])
+            try:
+                r = GeminiPriceResponse.parse_obj(d["response"])
+            except ValidationError as e:
+                logger.error("Error parsing response from Gemini API")
 
             if r.last is not None:
                 return r.last, datetime_now_utc()

--- a/src/telliot_feed_examples/sources/price/spot/gemini.py
+++ b/src/telliot_feed_examples/sources/price/spot/gemini.py
@@ -3,7 +3,8 @@ from dataclasses import field
 from typing import Any
 from typing import Dict
 
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel
+from pydantic import ValidationError
 from telliot_core.dtypes.datapoint import datetime_now_utc
 from telliot_core.dtypes.datapoint import OptionalDataPoint
 from telliot_core.pricing.price_service import WebPriceService
@@ -59,7 +60,7 @@ class GeminiSpotPriceService(WebPriceService):
         else:
             try:
                 r = GeminiPriceResponse.parse_obj(d["response"])
-            except ValidationError as e:
+            except ValidationError:
                 logger.error("Error parsing response from Gemini API")
 
             if r.last is not None:

--- a/tests/sources/test_gas_price_oracle_source.py
+++ b/tests/sources/test_gas_price_oracle_source.py
@@ -13,7 +13,7 @@ async def test_fetch_new_datapoint():
     timestamp = time() - 2000
     chain_id = 1
 
-    v, t = await GasPriceOracleSource().fetch_new_datapoint(timestamp, chain_id)
+    v, t = await GasPriceOracleSource(chain_id=chain_id, timestamp=timestamp).fetch_new_datapoint()
 
     assert v is not None and t is not None
     assert isinstance(v, float)

--- a/tests/sources/test_gas_price_oracle_source.py
+++ b/tests/sources/test_gas_price_oracle_source.py
@@ -13,7 +13,9 @@ async def test_fetch_new_datapoint():
     timestamp = time() - 2000
     chain_id = 1
 
-    v, t = await GasPriceOracleSource(chain_id=chain_id, timestamp=timestamp).fetch_new_datapoint()
+    v, t = await GasPriceOracleSource(
+        chain_id=chain_id, timestamp=timestamp
+    ).fetch_new_datapoint()
 
     assert v is not None and t is not None
     assert isinstance(v, float)

--- a/tests/sources/test_spot_price_sources.py
+++ b/tests/sources/test_spot_price_sources.py
@@ -3,7 +3,6 @@
 """
 import os
 from datetime import datetime
-from pydantic import NoneIsAllowedError
 
 import pytest
 from requests import JSONDecodeError
@@ -190,9 +189,10 @@ async def test_coingecko_price_service_rate_limit(caplog):
     assert dt is None
     assert "CoinGecko API rate limit exceeded" in caplog.text
 
+
 @pytest.mark.asyncio
 async def test_failed_price_service_request():
-    '''Assert web price service catches failed requests'''
+    """Assert web price service catches failed requests"""
 
     invalid_token_ticker = "abcxyz"
 
@@ -200,4 +200,3 @@ async def test_failed_price_service_request():
 
     assert v is None
     assert t is None
-

--- a/tests/sources/test_spot_price_sources.py
+++ b/tests/sources/test_spot_price_sources.py
@@ -3,6 +3,7 @@
 """
 import os
 from datetime import datetime
+from pydantic import NoneIsAllowedError
 
 import pytest
 from requests import JSONDecodeError
@@ -188,3 +189,15 @@ async def test_coingecko_price_service_rate_limit(caplog):
     assert v is None
     assert dt is None
     assert "CoinGecko API rate limit exceeded" in caplog.text
+
+@pytest.mark.asyncio
+async def test_failed_price_service_request():
+    '''Assert web price service catches failed requests'''
+
+    invalid_token_ticker = "abcxyz"
+
+    v, t = await get_price(invalid_token_ticker, "usd", service["gemini"])
+
+    assert v is None
+    assert t is None
+


### PR DESCRIPTION
closes #182 

get requests with python `requests` library returns a message, even if the http request was unsuccessful. This update catches bad requests in the WebPriceService class. This will prevent telliot from crashing on an unsuccessful API request.

Tested on the GeminiPriceService to match #182 