### PR TITLE
Fix DIVA query imports

### DIFF
--- a/src/telliot_feed_examples/feeds/diva_protocol_feed.py
+++ b/src/telliot_feed_examples/feeds/diva_protocol_feed.py
@@ -48,7 +48,6 @@ async def get_pool_params(
         logger.error("Error getting pool params from Diva contract.")
         return None
 
-    print("PARAMS:", params)
     pool_params = DivaPoolParameters(
         reference_asset=params.reference_asset, expiry_date=params.expiry_time
     )

--- a/src/telliot_feed_examples/feeds/diva_protocol_feed.py
+++ b/src/telliot_feed_examples/feeds/diva_protocol_feed.py
@@ -6,7 +6,7 @@ from typing import Optional
 from chained_accounts import ChainedAccount
 from telliot_core.api import DataFeed
 from telliot_core.model.endpoints import RPCEndpoint
-from telliot_core.queries.diva_protocol import divaProtocolPolygon
+from telliot_core.queries.diva_protocol import DIVAProtocolPolygon
 from telliot_core.tellor.tellorflex.diva import DivaProtocolContract
 
 from telliot_feed_examples.sources.price.historical.cryptowatch import (
@@ -95,7 +95,7 @@ async def assemble_diva_datafeed(
     ts = params.expiry_date
 
     feed = DataFeed(
-        query=divaProtocolPolygon(pool_id),
+        query=DIVAProtocolPolygon(pool_id),
         source=get_source(asset, ts),
     )
 

--- a/tests/feeds/test_diva_feed.py
+++ b/tests/feeds/test_diva_feed.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import pytest
 from telliot_core.api import DataFeed
 from telliot_core.apps.core import TelliotCore
-from telliot_core.queries.diva_protocol import divaProtocolPolygon
+from telliot_core.queries.diva_protocol import DIVAProtocolPolygon
 
 from telliot_feed_examples.feeds.diva_protocol_feed import assemble_diva_datafeed
 from telliot_feed_examples.feeds.diva_protocol_feed import DivaPoolParameters
@@ -41,7 +41,7 @@ async def test_diva_datafeed(ropsten_cfg) -> None:
         )
 
         assert isinstance(feed, DataFeed)
-        assert isinstance(feed.query, divaProtocolPolygon)
+        assert isinstance(feed.query, DIVAProtocolPolygon)
         assert isinstance(feed.source.sources[3], PoloniexHistoricalPriceSource)
         assert isinstance(feed.source.sources[0].ts, int)
         assert feed.source.asset == "eth"


### PR DESCRIPTION
Tests were erroring out because the import statements needed to be update bc of `telliot-core` changes