### PR TITLE
Unskips tests, removes args from fetch_data_point()

### DIFF
--- a/src/telliot_feed_examples/feeds/gas_price_oracle_feed.py
+++ b/src/telliot_feed_examples/feeds/gas_price_oracle_feed.py
@@ -16,5 +16,6 @@ chain_id = 1
 timestamp = 1648771200  # april 1, 2022 unix time
 
 gas_price_oracle_feed = DataFeed(
-    query=GasPriceOracle(chain_id, timestamp), source=GasPriceOracleSource()
+    query=GasPriceOracle(chain_id, timestamp),
+    source=GasPriceOracleSource(chain_id=chain_id, timestamp=timestamp),
 )

--- a/tests/feeds/test_gas_price_oracle_feed.py
+++ b/tests/feeds/test_gas_price_oracle_feed.py
@@ -2,17 +2,15 @@ from datetime import datetime
 
 import pytest
 
-from telliot_feed_examples.feeds.gas_price_oracle_feed import chain_id
 from telliot_feed_examples.feeds.gas_price_oracle_feed import gas_price_oracle_feed
-from telliot_feed_examples.feeds.gas_price_oracle_feed import timestamp
 
 
-@pytest.mark.skip("TODO: Fix")
+# @pytest.mark.skip("TODO: Fix")
 @pytest.mark.asyncio
 async def test_fetch_new_datapoint():
     """Retrieve historical gas price data from source."""
 
-    v, t = await gas_price_oracle_feed.source.fetch_new_datapoint(timestamp, chain_id)
+    v, t = await gas_price_oracle_feed.source.fetch_new_datapoint()
 
     assert v is not None and t is not None
     assert isinstance(v, float)

--- a/tests/feeds/test_gas_price_oracle_feed.py
+++ b/tests/feeds/test_gas_price_oracle_feed.py
@@ -5,7 +5,6 @@ import pytest
 from telliot_feed_examples.feeds.gas_price_oracle_feed import gas_price_oracle_feed
 
 
-# @pytest.mark.skip("TODO: Fix")
 @pytest.mark.asyncio
 async def test_fetch_new_datapoint():
     """Retrieve historical gas price data from source."""


### PR DESCRIPTION
Closes #187 

For compatibility the `IntervalReporter` interface, I removed the arguments for `GasPriceOracleSource.fetch_data_point()`, which used to be `chain_id` and 'timestamp`. 