### PR TITLE
Unskip rate limited tests & active feeds

### DIFF
--- a/tests/feeds/test_active_feeds.py
+++ b/tests/feeds/test_active_feeds.py
@@ -1,10 +1,8 @@
-import pytest
 from telliot_core.data.query_catalog import query_catalog
 
 from telliot_feed_examples.feeds import CATALOG_FEEDS
 
 
-@pytest.mark.skip("TODO: add gp oracle to CATALOG_FEEDS")
 def test_supports_all_active_queries():
     """Make sure all current queries have an associated feed that reporters can use."""
     active_q_tags = [q.tag for q in query_catalog.find()]

--- a/tests/feeds/test_bct_usd_feed.py
+++ b/tests/feeds/test_bct_usd_feed.py
@@ -3,7 +3,6 @@ import pytest
 from telliot_feed_examples.feeds.bct_usd_feed import bct_usd_median_feed
 
 
-@pytest.mark.skip("Avoid coingecko rate limits")
 @pytest.mark.asyncio
 async def test_fetch_price():
     (value, _) = await bct_usd_median_feed.source.fetch_new_datapoint()

--- a/tests/feeds/test_idle_usd_feed.py
+++ b/tests/feeds/test_idle_usd_feed.py
@@ -3,7 +3,6 @@ import pytest
 from telliot_feed_examples.feeds.idle_usd_feed import idle_usd_median_feed
 
 
-@pytest.mark.skip("Avoid coingecko rate limits")
 @pytest.mark.asyncio
 async def test_fetch_price():
     (value, _) = await idle_usd_median_feed.source.fetch_new_datapoint()

--- a/tests/feeds/test_matic_usd_feed.py
+++ b/tests/feeds/test_matic_usd_feed.py
@@ -3,7 +3,6 @@ import pytest
 from telliot_feed_examples.feeds.matic_usd_feed import matic_usd_median_feed
 
 
-@pytest.mark.skip("Avoid coingecko rate limits")
 @pytest.mark.asyncio
 async def test_fetch_price():
     (value, _) = await matic_usd_median_feed.source.fetch_new_datapoint()

--- a/tests/feeds/test_mkr_usd_feed.py
+++ b/tests/feeds/test_mkr_usd_feed.py
@@ -3,7 +3,6 @@ import pytest
 from telliot_feed_examples.feeds.mkr_usd_feed import mkr_usd_median_feed
 
 
-@pytest.mark.skip("Avoid coingecko rate limits")
 @pytest.mark.asyncio
 async def test_fetch_price():
     (value, _) = await mkr_usd_median_feed.source.fetch_new_datapoint()

--- a/tests/feeds/test_ric_usd_feed.py
+++ b/tests/feeds/test_ric_usd_feed.py
@@ -3,7 +3,6 @@ import pytest
 from telliot_feed_examples.feeds.ric_usd_feed import ric_usd_median_feed
 
 
-@pytest.mark.skip("Avoid coingecko rate limits")
 @pytest.mark.asyncio
 async def test_fetch_price():
     (value, _) = await ric_usd_median_feed.source.fetch_new_datapoint()

--- a/tests/feeds/test_sushi_usd_feed.py
+++ b/tests/feeds/test_sushi_usd_feed.py
@@ -3,7 +3,6 @@ import pytest
 from telliot_feed_examples.feeds.sushi_usd_feed import sushi_usd_median_feed
 
 
-@pytest.mark.skip("Avoid coingecko rate limits")
 @pytest.mark.asyncio
 async def test_fetch_price():
     (value, _) = await sushi_usd_median_feed.source.fetch_new_datapoint()

--- a/tests/feeds/test_usdc_usd_feed.py
+++ b/tests/feeds/test_usdc_usd_feed.py
@@ -3,7 +3,6 @@ import pytest
 from telliot_feed_examples.feeds.usdc_usd_feed import usdc_usd_median_feed
 
 
-@pytest.mark.skip("Avoid coingecko rate limits")
 @pytest.mark.asyncio
 async def test_fetch_price():
     (value, _) = await usdc_usd_median_feed.source.fetch_new_datapoint()


### PR DESCRIPTION
If tests start failing because of coingecko rate limits, then they should detect that by reading the output from the logs