### PR TITLE
add tellorrng cli support

### DIFF
--- a/src/telliot_feed_examples/cli.py
+++ b/src/telliot_feed_examples/cli.py
@@ -506,15 +506,6 @@ async def tip(
     required=True,
 )
 @click.option(
-    "--rng-timestamp",
-    "-rngts",
-    "rng_timestamp",
-    help="timestamp for Tellor RNG",
-    nargs=1,
-    type=int,
-    required=True,
-)
-@click.option(
     "--gas-price",
     "-gp",
     "legacy_gas_price",

--- a/src/telliot_feed_examples/cli.py
+++ b/src/telliot_feed_examples/cli.py
@@ -19,12 +19,12 @@ from telliot_core.tellor.tellorflex.diva import DivaOracleTellorContract
 
 from telliot_feed_examples.feeds import CATALOG_FEEDS
 from telliot_feed_examples.feeds.diva_protocol_feed import assemble_diva_datafeed
+from telliot_feed_examples.feeds.tellor_rng_feed import assemble_rng_datafeed
 from telliot_feed_examples.reporters.flashbot import FlashbotsReporter
 from telliot_feed_examples.reporters.interval import IntervalReporter
 from telliot_feed_examples.reporters.tellorflex import PolygonReporter
 from telliot_feed_examples.utils.log import get_logger
 from telliot_feed_examples.utils.oracle_write import tip_query
-
 
 logger = get_logger(__name__)
 
@@ -87,6 +87,7 @@ def print_reporter_settings(
     legacy_gas_price: Optional[int],
     gas_price_speed: str,
     diva_pool_id: Optional[int],
+    rng_timestamp: Optional[int],
 ) -> None:
     """Print user settings to console."""
     click.echo("")
@@ -263,6 +264,14 @@ def cli(
     nargs=1,
     type=int,
 )
+@click.option(
+    "--rng-timestamp",
+    "-rngts",
+    "rng_timestamp",
+    help="timestamp for Tellor RNG",
+    nargs=1,
+    type=int,
+)
 @click.option("--submit-once/--submit-continuous", default=False)
 @click.option("-pwd", "--password", type=str)
 @click.option("-spwd", "--signature-password", type=str)
@@ -280,6 +289,7 @@ async def report(
     submit_once: bool,
     gas_price_speed: str,
     diva_pool_id: int,
+    rng_timestamp: int,
     password: str,
     signature_password: str,
 ) -> None:
@@ -343,6 +353,10 @@ async def report(
             chosen_feed = await assemble_diva_datafeed(
                 pool_id=diva_pool_id, node=core.endpoint, account=account
             )
+        elif rng_timestamp is not None:
+            chosen_feed = await assemble_rng_datafeed(
+                timestamp=rng_timestamp, node=core.endpoint, account=account
+            )
         else:
             chosen_feed = None
 
@@ -358,6 +372,7 @@ async def report(
             chain_id=cid,
             gas_price_speed=gas_price_speed,
             diva_pool_id=diva_pool_id,
+            rng_timestamp=rng_timestamp,
         )
 
         _ = input("Press [ENTER] to confirm settings.")
@@ -474,6 +489,15 @@ async def tip(
     "-pid",
     "pool_id",
     help="pool ID for Diva Protocol on Polygon",
+    nargs=1,
+    type=int,
+    required=True,
+)
+@click.option(
+    "--rng-timestamp",
+    "-rngts",
+    "rng_timestamp",
+    help="timestamp for Tellor RNG",
     nargs=1,
     type=int,
     required=True,

--- a/src/telliot_feed_examples/feeds/tellor_rng_feed.py
+++ b/src/telliot_feed_examples/feeds/tellor_rng_feed.py
@@ -19,7 +19,7 @@ async def assemble_rng_datafeed(
     timestamp: int, node: RPCEndpoint, account: chained_accounts
 ) -> Optional[DataFeed[float]]:
     """Assembles a TellorRNG datafeed for the given timestamp."""
-    local_source.setTimestamp(timestamp)
+    local_source.set_timestamp(timestamp)
     feed = DataFeed(source=local_source, query=TellorRNG(timestamp=timestamp))
 
     return feed

--- a/src/telliot_feed_examples/feeds/tellor_rng_feed.py
+++ b/src/telliot_feed_examples/feeds/tellor_rng_feed.py
@@ -1,5 +1,9 @@
 """Datafeed for pseudorandom number from hashing multiple blockhashes together."""
+from typing import Optional
+
+import chained_accounts
 from telliot_core.datafeed import DataFeed
+from telliot_core.model.endpoints import RPCEndpoint
 from telliot_core.queries.tellor_rng import TellorRNG
 
 from telliot_feed_examples.sources.blockhash_aggregator import TellorRNGManualSource
@@ -9,3 +13,13 @@ local_source = TellorRNGManualSource()
 tellor_rng_feed = DataFeed(
     source=local_source, query=TellorRNG(timestamp=local_source.timestamp)
 )
+
+
+async def assemble_rng_datafeed(
+    timestamp: int, node: RPCEndpoint, account: chained_accounts
+) -> Optional[DataFeed[float]]:
+    """Assembles a TellorRNG datafeed for the given timestamp."""
+    local_source.setTimestamp(timestamp)
+    feed = DataFeed(source=local_source, query=TellorRNG(timestamp=timestamp))
+
+    return feed

--- a/src/telliot_feed_examples/sources/blockhash_aggregator.py
+++ b/src/telliot_feed_examples/sources/blockhash_aggregator.py
@@ -142,6 +142,9 @@ class TellorRNGManualSource(DataSource[Any]):
 
             return str(block["hash"])
 
+    def setTimestamp(self, timestamp: int) -> None:
+        self.timestamp = timestamp
+
     async def fetch_new_datapoint(self) -> DataPoint[bytes]:
         """Update current value with time-stamped value fetched from user input.
 

--- a/src/telliot_feed_examples/sources/blockhash_aggregator.py
+++ b/src/telliot_feed_examples/sources/blockhash_aggregator.py
@@ -144,7 +144,7 @@ class TellorRNGManualSource(DataSource[Any]):
 
     timestamp = 0
 
-    def setTimestamp(self, timestamp: int) -> None:
+    def set_timestamp(self, timestamp: int) -> None:
         self.timestamp = timestamp
 
     def parse_user_val(self) -> int:

--- a/src/telliot_feed_examples/sources/blockhash_aggregator.py
+++ b/src/telliot_feed_examples/sources/blockhash_aggregator.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from datetime import timezone
 from typing import Any
 from typing import Optional
+from typing import Tuple
 
 import requests
 from requests import JSONDecodeError
@@ -41,7 +42,7 @@ def block_num_from_timestamp(timestamp: int) -> Optional[int]:
                 "?module=block"
                 "&action=getblocknobytime"
                 f"&timestamp={timestamp}"
-                "&closest=after"
+                "&closest=before"
                 "&apikey="
             )
         except requests.exceptions.ConnectTimeout:
@@ -98,7 +99,7 @@ async def get_eth_hash(timestamp: int) -> Optional[str]:
     return str(block["hash"].hex())
 
 
-async def get_btc_hash(timestamp: int) -> Optional[str]:
+async def get_btc_hash(timestamp: int) -> Tuple[Optional[str], Optional[int]]:
     """Fetches next Bitcoin blockhash after timestamp from API."""
     with requests.Session() as s:
         s.mount("https://", adapter)
@@ -108,24 +109,24 @@ async def get_btc_hash(timestamp: int) -> Optional[str]:
             rsp = s.get(f" https://blockchain.info/blocks/{ts * 1000}?format=json")
         except requests.exceptions.ConnectTimeout:
             logger.error("Connection timeout getting BTC block num from timestamp")
-            return None
+            return None, None
         except requests.exceptions.RequestException as e:
             logger.error(f"Blockchain.info API error: {e}")
-            return None
+            return None, None
 
         try:
             blocks = rsp.json()
         except JSONDecodeError:
             logger.error("Blockchain.info API returned invalid JSON")
-            return None
+            return None, None
 
         if len(blocks) == 0:
             logger.warning("Blockchain.info API returned no blocks")
-            return None
+            return None, None
 
         if "time" not in blocks[0]:
             logger.warning("Blockchain.info response doesn't contain needed data")
-            return None
+            return None, None
 
         block = blocks[0]
         for b in blocks[::-1]:
@@ -134,7 +135,7 @@ async def get_btc_hash(timestamp: int) -> Optional[str]:
             block = b
             break
 
-        return str(block["hash"])
+        return str(block["hash"]), block["time"]
 
 
 @dataclass
@@ -181,15 +182,18 @@ class TellorRNGManualSource(DataSource[Any]):
             timestamp = self.parse_user_val()
         else:
             timestamp = self.timestamp
-        eth_hash, btc_hash = await asyncio.gather(
-            get_eth_hash(timestamp), get_btc_hash(timestamp)
-        )
 
-        if eth_hash is None:
-            logger.warning("Unable to retrieve Ethereum blockhash")
-            return None, None
+        btc_hash, btc_timestamp = await get_btc_hash(timestamp)
+
         if btc_hash is None:
             logger.warning("Unable to retrieve Bitcoin blockhash")
+            return None, None
+        if btc_timestamp is None:
+            logger.warning("Unable to retrieve Bitcoin timestamp")
+            return None, None
+        eth_hash = await get_eth_hash(btc_timestamp)
+        if eth_hash is None:
+            logger.warning("Unable to retrieve Ethereum blockhash")
             return None, None
 
         data = Web3.solidityKeccak(["string", "string"], [eth_hash, btc_hash])
@@ -199,5 +203,15 @@ class TellorRNGManualSource(DataSource[Any]):
         self.store_datapoint(datapoint)
 
         logger.info(f"Stored random number for timestamp {timestamp}: {data}")
-
         return datapoint
+
+
+async def main() -> None:
+    """Runs the data source."""
+    source = TellorRNGManualSource()
+    await source.fetch_new_datapoint()
+
+
+if __name__ == "__main__":
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(main())

--- a/src/telliot_feed_examples/sources/blockhash_aggregator.py
+++ b/src/telliot_feed_examples/sources/blockhash_aggregator.py
@@ -102,7 +102,7 @@ async def get_btc_hash(timestamp: int) -> Optional[str]:
     """Fetches next Bitcoin blockhash after timestamp from API."""
     with requests.Session() as s:
         s.mount("https://", adapter)
-        ts = timestamp + 15 * 60
+        ts = timestamp + 30 * 60
 
         try:
             rsp = s.get(f" https://blockchain.info/blocks/{ts * 1000}?format=json")
@@ -127,7 +127,7 @@ async def get_btc_hash(timestamp: int) -> Optional[str]:
             logger.warning("Blockchain.info response doesn't contain needed data")
             return None
 
-        block: dict[str, Any]
+        block = blocks[0]
         for b in blocks[::-1]:
             if b["time"] < timestamp:
                 continue

--- a/tests/sources/test_tellor_rng_source.py
+++ b/tests/sources/test_tellor_rng_source.py
@@ -13,13 +13,13 @@ from telliot_feed_examples.sources.blockhash_aggregator import TellorRNGManualSo
 @pytest.mark.asyncio
 async def test_rng():
     """Retrieve random number."""
-    blockhash_aggregator.input = lambda: "1649769707"  # BCT block num: 731547
+    blockhash_aggregator.input = lambda: "1652075943"  # BCT block num: 731547
     rng_source = TellorRNGManualSource()
     v, t = await rng_source.fetch_new_datapoint()
 
     assert v == (
-        b"Ad\x81\xc2\x9d\xab\x8a\xf6\x8fN^\xcd\xb9g\xdf{"
-        b"\xeap\xe4\xf8\xf2\xab\x89\xcb\xb0\xe6\x8cGR\x18\xf2+"
+        b"\x9diF\xd9R\xf1>q%\x13F\x11\xad\x9f]\xccA\x08"
+        b"\xd9\x03Y\xb0#\x94\xd8\xefgi\xcc\x85t\xb3"
     )
 
     assert isinstance(v, bytes)
@@ -37,9 +37,14 @@ async def test_rng_failures(caplog):
     with mock.patch("requests.Session.get", side_effect=conn_timeout):
         for hash_source in [
             get_eth_hash,
-            get_btc_hash,
         ]:
             h = await hash_source(timestamp)
+            assert h is None
+            assert "Connection timeout" in caplog.text
+        for hash_source in [
+            get_btc_hash,
+        ]:
+            h, j = await hash_source(timestamp)
             assert h is None
             assert "Connection timeout" in caplog.text
 
@@ -52,8 +57,13 @@ async def test_rng_failures(caplog):
     with mock.patch("requests.Session.get", side_effect=bad_json):
         for hash_source in [
             get_eth_hash,
-            get_btc_hash,
         ]:
             h = await hash_source(timestamp)
+            assert h is None
+            assert "invalid JSON" in caplog.text
+        for hash_source in [
+            get_btc_hash,
+        ]:
+            h, j = await hash_source(timestamp)
             assert h is None
             assert "invalid JSON" in caplog.text


### PR DESCRIPTION
- adds support for reporting TellorRNG values using telliot cli
- use commands: `--rng-timestamp`, `-rngts`, or `rng_timestamp` followed by the desired timestamp argument