### PR TITLE
Update USPCE source

### DIFF
--- a/src/telliot_feeds/feeds/uspce_feed.py
+++ b/src/telliot_feeds/feeds/uspce_feed.py
@@ -1,7 +1,7 @@
 """Example datafeed used by USPCEReporter."""
 from telliot_feeds.datafeed import DataFeed
 from telliot_feeds.queries.ampleforth.uspce import AmpleforthUSPCE
-from telliot_feeds.sources.manual.uspce import USPCESource
+from telliot_feeds.sources.bea_gov import BEAPCESource
 
 
-uspce_feed = DataFeed(query=AmpleforthUSPCE(), source=USPCESource())
+uspce_feed = DataFeed(query=AmpleforthUSPCE(), source=BEAPCESource())

--- a/src/telliot_feeds/sources/bea_gov.py
+++ b/src/telliot_feeds/sources/bea_gov.py
@@ -1,0 +1,149 @@
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from decimal import InvalidOperation
+from typing import Any
+from typing import Optional
+
+import requests
+from telliot_core.apps.telliot_config import TelliotConfig
+
+from telliot_feeds.datasource import DataSource
+from telliot_feeds.dtypes.datapoint import datetime_now_utc
+from telliot_feeds.dtypes.datapoint import OptionalDataPoint
+from telliot_feeds.utils.log import get_logger
+
+
+logger = get_logger(__name__)
+
+BEA_API_URL = "https://apps.bea.gov/api/data"
+NIPA_TABLE_NAME = "T20804"
+PCE_LINE_NUMBER = "1"
+PCE_AVERAGE_QUANT = Decimal("0.000000000000000001")
+
+
+def load_bea_api_key() -> Optional[str]:
+    """Load the BEA API key from telliot's api_keys.yaml config."""
+    keys = TelliotConfig().api_keys
+    for name in ("BEA", "bea"):
+        api_keys = keys.find(name=name)
+        if api_keys and api_keys[0].key:
+            return api_keys[0].key
+    return None
+
+
+def _parse_month_period(period: Any) -> Optional[datetime]:
+    """Parse BEA monthly periods such as 2026M01."""
+    if not isinstance(period, str) or "M" not in period:
+        return None
+
+    year, month = period.split("M", maxsplit=1)
+    try:
+        return datetime(year=int(year), month=int(month), day=1)
+    except ValueError:
+        return None
+
+
+def _parse_decimal(value: Any) -> Optional[Decimal]:
+    """Parse BEA numeric strings, including comma-grouped values."""
+    if value is None:
+        return None
+
+    try:
+        return Decimal(str(value).replace(",", ""))
+    except InvalidOperation:
+        return None
+
+
+@dataclass
+class BEAPCESource(DataSource[Decimal]):
+    """DataSource for the three-month moving average USPCE value from BEA."""
+
+    api_key: Optional[str] = None
+    url: str = BEA_API_URL
+    table_name: str = NIPA_TABLE_NAME
+    line_number: str = PCE_LINE_NUMBER
+    year: str = "X"
+    request_timeout: int = 10
+
+    def get_pce_data(self) -> Optional[dict[str, Any]]:
+        """Retrieve PCE price index data from the BEA NIPA API."""
+        api_key = self.api_key or load_bea_api_key()
+        if not api_key:
+            logger.error("BEA API key not found in api_keys.yaml.")
+            return None
+
+        params = {
+            "UserID": api_key,
+            "datasetname": "NIPA",
+            "method": "GetData",
+            "TableName": self.table_name,
+            "LineNumber": self.line_number,
+            "Frequency": "M",
+            "Year": self.year,
+            "ResultFormat": "JSON",
+        }
+
+        try:
+            with requests.Session() as session:
+                response = session.get(self.url, params=params, timeout=self.request_timeout)
+                response.raise_for_status()
+                data = response.json()
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Error retrieving PCE data from BEA: {e}")
+            return None
+        except ValueError as e:
+            logger.error(f"Error parsing BEA response JSON: {e}")
+            return None
+
+        return data
+
+    def calculate_3month_average(self, data: dict[str, Any]) -> Optional[Decimal]:
+        """Calculate the latest three-month average for headline PCE."""
+        results = data.get("BEAAPI", {}).get("Results", {})
+        rows = results.get("Data", [])
+        values: list[tuple[datetime, str, Decimal]] = []
+
+        notes = results.get("Notes", [])
+        if notes and isinstance(notes[0], dict):
+            logger.info(f"BEA PCE source note: {notes[0].get('NoteText')}")
+
+        for row in rows:
+            if not isinstance(row, dict) or str(row.get("LineNumber")) != self.line_number:
+                continue
+
+            raw_period = row.get("TimePeriod")
+            period = _parse_month_period(raw_period)
+            value = _parse_decimal(row.get("DataValue"))
+            if period is None or value is None:
+                continue
+
+            values.append((period, str(raw_period), value))
+
+        if len(values) < 3:
+            logger.error("BEA response did not include at least three monthly PCE values.")
+            return None
+
+        latest_entries = sorted(values, key=lambda item: item[0])[-3:]
+        averaged_values = ", ".join(f"{raw_period}={value}" for _, raw_period, value in latest_entries)
+        logger.info(f"BEA PCE inputs for 3-month average: {averaged_values}")
+
+        latest_values = [value for _, _, value in latest_entries]
+        average = sum(latest_values, Decimal("0")) / Decimal(len(latest_values))
+        return average.quantize(PCE_AVERAGE_QUANT)
+
+    async def fetch_new_datapoint(self) -> OptionalDataPoint[Decimal]:
+        """Fetch, calculate, and store the latest USPCE datapoint."""
+        data = self.get_pce_data()
+        if data is None:
+            return None, None
+
+        average = self.calculate_3month_average(data)
+        if average is None:
+            return None, None
+
+        datapoint = (average, datetime_now_utc())
+        self.store_datapoint(datapoint)
+
+        logger.info(f"USPCE {datapoint[0]} retrieved from BEA at time {datapoint[1]}")
+        return datapoint

--- a/src/telliot_feeds/sources/bea_gov.py
+++ b/src/telliot_feeds/sources/bea_gov.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from decimal import Decimal
 from decimal import InvalidOperation
 from typing import Any
+from typing import cast
 from typing import Optional
 
 import requests
@@ -28,7 +29,7 @@ def load_bea_api_key() -> Optional[str]:
     for name in ("BEA", "bea"):
         api_keys = keys.find(name=name)
         if api_keys and api_keys[0].key:
-            return api_keys[0].key
+            return cast(str, api_keys[0].key)
     return None
 
 
@@ -88,7 +89,7 @@ class BEAPCESource(DataSource[Decimal]):
             with requests.Session() as session:
                 response = session.get(self.url, params=params, timeout=self.request_timeout)
                 response.raise_for_status()
-                data = response.json()
+                data = cast(dict[str, Any], response.json())
         except requests.exceptions.RequestException as e:
             logger.error(f"Error retrieving PCE data from BEA: {e}")
             return None

--- a/tests/feeds/test_uspce_feed.py
+++ b/tests/feeds/test_uspce_feed.py
@@ -1,5 +1,5 @@
-import yaml
 import pytest
+import yaml
 
 from telliot_feeds.feeds.uspce_feed import uspce_feed
 from telliot_feeds.sources.bea_gov import BEAPCESource

--- a/tests/feeds/test_uspce_feed.py
+++ b/tests/feeds/test_uspce_feed.py
@@ -1,8 +1,25 @@
+from decimal import Decimal
+from unittest import mock
+
 import pytest
 import yaml
 
 from telliot_feeds.feeds.uspce_feed import uspce_feed
 from telliot_feeds.sources.bea_gov import BEAPCESource
+from telliot_feeds.sources.bea_gov import PCE_LINE_NUMBER
+
+
+SAMPLE_RESPONSE = {
+    "BEAAPI": {
+        "Results": {
+            "Data": [
+                {"LineNumber": PCE_LINE_NUMBER, "TimePeriod": "2026M01", "DataValue": "126.100"},
+                {"LineNumber": PCE_LINE_NUMBER, "TimePeriod": "2026M02", "DataValue": "126.200"},
+                {"LineNumber": PCE_LINE_NUMBER, "TimePeriod": "2026M03", "DataValue": "126.300"},
+            ]
+        }
+    }
+}
 
 
 @pytest.mark.asyncio
@@ -13,9 +30,11 @@ async def test_uspce_feed():
     print(yaml.dump(feed.get_state(), sort_keys=False))
     assert isinstance(feed.source, BEAPCESource)
 
-    value, timestamp = await feed.source.fetch_new_datapoint()
+    with mock.patch.object(feed.source, "get_pce_data", return_value=SAMPLE_RESPONSE):
+        value, timestamp = await feed.source.fetch_new_datapoint()
+
     print(f"USPCE report value: {value}")
     print(f"USPCE report timestamp: {timestamp}")
 
-    assert value is not None
+    assert value == Decimal("126.200000000000000000")
     assert timestamp is not None

--- a/tests/feeds/test_uspce_feed.py
+++ b/tests/feeds/test_uspce_feed.py
@@ -1,10 +1,21 @@
 import yaml
+import pytest
 
 from telliot_feeds.feeds.uspce_feed import uspce_feed
+from telliot_feeds.sources.bea_gov import BEAPCESource
 
 
-def test_manual_uspce_feed():
+@pytest.mark.asyncio
+async def test_uspce_feed():
     """Test USPCE feed."""
     feed = uspce_feed
 
     print(yaml.dump(feed.get_state(), sort_keys=False))
+    assert isinstance(feed.source, BEAPCESource)
+
+    value, timestamp = await feed.source.fetch_new_datapoint()
+    print(f"USPCE report value: {value}")
+    print(f"USPCE report timestamp: {timestamp}")
+
+    assert value is not None
+    assert timestamp is not None

--- a/tests/sources/test_bea_gov_source.py
+++ b/tests/sources/test_bea_gov_source.py
@@ -1,0 +1,75 @@
+from datetime import datetime
+from decimal import Decimal
+from unittest import mock
+
+import pytest
+
+from telliot_feeds.sources.bea_gov import BEAPCESource
+from telliot_feeds.sources.bea_gov import NIPA_TABLE_NAME
+from telliot_feeds.sources.bea_gov import PCE_LINE_NUMBER
+
+
+SAMPLE_RESPONSE = {
+    "BEAAPI": {
+        "Results": {
+            "Data": [
+                {"LineNumber": PCE_LINE_NUMBER, "TimePeriod": "2026M02", "DataValue": "126.200"},
+                {"LineNumber": "2", "TimePeriod": "2026M03", "DataValue": "999.999"},
+                {"LineNumber": PCE_LINE_NUMBER, "TimePeriod": "2026M01", "DataValue": "126.100"},
+                {"LineNumber": PCE_LINE_NUMBER, "TimePeriod": "2025M12", "DataValue": "125.900"},
+                {"LineNumber": PCE_LINE_NUMBER, "TimePeriod": "2026M03", "DataValue": "126.300"},
+            ]
+        }
+    }
+}
+
+
+def test_calculate_3month_average():
+    """Calculate the latest three-month PCE average from BEA rows."""
+    source = BEAPCESource(api_key="test-key")
+
+    assert source.calculate_3month_average(SAMPLE_RESPONSE) == Decimal("126.200000000000000000")
+
+
+def test_calculate_3month_average_requires_three_values():
+    """Return None when fewer than three PCE months are available."""
+    source = BEAPCESource(api_key="test-key")
+    response = {
+        "BEAAPI": {
+            "Results": {
+                "Data": [
+                    {"LineNumber": PCE_LINE_NUMBER, "TimePeriod": "2026M02", "DataValue": "126.200"},
+                    {"LineNumber": PCE_LINE_NUMBER, "TimePeriod": "2026M03", "DataValue": "126.300"},
+                ]
+            }
+        }
+    }
+
+    assert source.calculate_3month_average(response) is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_new_datapoint():
+    """Fetch BEA data and store the calculated USPCE datapoint."""
+    response = mock.Mock()
+    response.json.return_value = SAMPLE_RESPONSE
+    session = mock.Mock()
+    session.get.return_value = response
+    session_context = mock.MagicMock()
+    session_context.__enter__.return_value = session
+
+    with mock.patch("telliot_feeds.sources.bea_gov.requests.Session", return_value=session_context):
+        source = BEAPCESource(api_key="test-key")
+        value, timestamp = await source.fetch_new_datapoint()
+
+    assert value == Decimal("126.200000000000000000")
+    assert isinstance(timestamp, datetime)
+    assert source.latest[0] == value
+
+    session.get.assert_called_once()
+    call_kwargs = session.get.call_args.kwargs
+    assert call_kwargs["params"]["UserID"] == "test-key"
+    assert call_kwargs["params"]["TableName"] == NIPA_TABLE_NAME
+    assert call_kwargs["params"]["LineNumber"] == PCE_LINE_NUMBER
+    assert call_kwargs["params"]["Frequency"] == "M"
+    assert call_kwargs["params"]["Year"] == "X"


### PR DESCRIPTION
### Summary
The most recent personal consumption and expenditures release did not include csv tables to use for calculating the 3 month moving USPCE average for Ampleforth. This PR updates telliot to use the bea.gov's api instead.

### Steps Taken to QA Changes
Detailed logging and proper tests provided. Reported on sepolia for sanity check:
https://sepolia.etherscan.io//tx/867cf5476971b29cb73f591e0c2625abb45a9552be2ada9cf2df05312c138989